### PR TITLE
Problem: igsagent.h defined igs_parameter_set_impulsion

### DIFF
--- a/api/igsagent.api
+++ b/api/igsagent.api
@@ -373,12 +373,6 @@
         <return type = "igs result t" callback = "1" />
     </method>
 
-    <method name = "parameter set impulsion">
-        DOC_STRING
-        <argument name = "name" type = "string" />
-        <return type = "igs result t" callback = "1" />
-    </method>
-
     <method name = "parameter set data">
         DOC_STRING
         <argument name = "name" type = "string" />

--- a/include/igsagent.h
+++ b/include/igsagent.h
@@ -168,7 +168,6 @@ INGESCAPE_EXPORT igs_result_t igsagent_parameter_set_bool (igsagent_t *self, con
 INGESCAPE_EXPORT igs_result_t igsagent_parameter_set_int (igsagent_t *self, const char *name, int value);
 INGESCAPE_EXPORT igs_result_t igsagent_parameter_set_double (igsagent_t *self, const char *name, double value);
 INGESCAPE_EXPORT igs_result_t igsagent_parameter_set_string (igsagent_t *self, const char *name, const char *value);
-INGESCAPE_EXPORT igs_result_t igsagent_parameter_set_impulsion (igsagent_t *self, const char *name);
 INGESCAPE_EXPORT igs_result_t igsagent_parameter_set_data (igsagent_t *self, const char *name, void *value, size_t size);
 
 /*These two functions enable sending and receiving DATA


### PR DESCRIPTION
- A parameter cannot be an `IGS_IMPULSION_T`
- The method has no definition

Solution: Remove the declaration from `igsagent.h` and `igsagent.api`