### PR TITLE
Problem : Impossible to re-create a splitter on an output when all workers have left the splitter

### DIFF
--- a/src/igs_split.c
+++ b/src/igs_split.c
@@ -253,8 +253,7 @@ void s_split_add_credit_to_worker (igs_core_context_t *context, char* agent_uuid
     bool splitter_found = false;
     igs_splitter_t *splitter;
     LL_FOREACH(context->splitters, splitter){
-        if(splitter->workers_list
-           && streq(splitter->agent_uuid, agent_uuid)
+        if(streq(splitter->agent_uuid, agent_uuid)
            && streq(splitter->output_name, output->name)){
             igs_worker_t *worker = NULL;
             int maxUses = 0;

--- a/src/igs_split.c
+++ b/src/igs_split.c
@@ -58,17 +58,17 @@ void split_remove_worker (igs_core_context_t *context, char *uuid, char *input_n
             splitter->agent_uuid = NULL;
             free(splitter->output_name);
             splitter->output_name = NULL;
-            igs_queued_work_t *elt, *tmp;
-            LL_FOREACH_SAFE(splitter->queued_works, elt, tmp){
-                LL_DELETE(splitter->queued_works, elt);
-                if(elt->value_type == IGS_DATA_T){
-                    free(elt->value.data);
-                    elt->value.data = NULL;
-                }else if(elt->value_type == IGS_STRING_T){
-                    free(elt->value.s);
-                    elt->value.s = NULL;
+            igs_queued_work_t *work_elt, *work_tmp;
+            LL_FOREACH_SAFE(splitter->queued_works, work_elt, work_tmp){
+                LL_DELETE(splitter->queued_works, work_elt);
+                if(work_elt->value_type == IGS_DATA_T){
+                    free(work_elt->value.data);
+                    work_elt->value.data = NULL;
+                }else if(work_elt->value_type == IGS_STRING_T){
+                    free(work_elt->value.s);
+                    work_elt->value.s = NULL;
                 }
-                free(elt);
+                free(work_elt);
             }
             free(splitter->queued_works);
             splitter->queued_works = NULL;

--- a/src/igs_split.c
+++ b/src/igs_split.c
@@ -60,6 +60,7 @@ void split_remove_worker (igs_core_context_t *context, char *uuid, char *input_n
             splitter->output_name = NULL;
             igs_queued_work_t *elt, *tmp;
             LL_FOREACH_SAFE(splitter->queued_works, elt, tmp){
+                LL_DELETE(splitter->queued_works, elt);
                 if(elt->value_type == IGS_DATA_T){
                     free(elt->value.data);
                     elt->value.data = NULL;
@@ -68,12 +69,10 @@ void split_remove_worker (igs_core_context_t *context, char *uuid, char *input_n
                     elt->value.s = NULL;
                 }
                 free(elt);
-                elt = NULL;
             }
             free(splitter->queued_works);
             splitter->queued_works = NULL;
             free(splitter);
-            splitter = NULL;
         }
     }
 }


### PR DESCRIPTION
Problem : Impossible to re-create a splitter on an output when all workers have left the splitter.

Solution : Remove useless test + destroy splitter when all of its workers have left as incoming workers shall not receive data emitted when they where no workers 