### PR TITLE
Make a CPack target to build a .deb package on Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,6 @@ if(OSX_UNIVERSAL)
     set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Build universal binaries")
 endif(OSX_UNIVERSAL)
 
-project(ingescape HOMEPAGE_URL https://ingescape.com LANGUAGES C)
-
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED ON)
-ADD_DEFINITIONS (-DZYRE_BUILD_DRAFT_API)
-ADD_DEFINITIONS (-DCZMQ_BUILD_DRAFT_API)
-
 # Add path to custom macro
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/modules/library")
@@ -26,6 +19,18 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/modules/
 # Include custom helpers
 include(IngescapeHelper)
 include(IdentifyOS)
+
+# gets version from admin.c file
+get_ingescape_version(INGESCAPE_VERSION_MAJOR INGESCAPE_VERSION_MINOR INGESCAPE_VERSION_PATCH)
+set(INGESCAPE_VERSION "${INGESCAPE_VERSION_MAJOR}.${INGESCAPE_VERSION_MINOR}.${INGESCAPE_VERSION_PATCH}")
+message(STATUS "Detected INGESCAPE Version - ${INGESCAPE_VERSION}")
+
+project(ingescape VERSION ${INGESCAPE_VERSION} HOMEPAGE_URL https://ingescape.com LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+ADD_DEFINITIONS (-DZYRE_BUILD_DRAFT_API)
+ADD_DEFINITIONS (-DCZMQ_BUILD_DRAFT_API)
 
 # Option to only generate dependencies.
 # Used to setup developmenent environment.
@@ -80,11 +85,6 @@ if(NOT MSVC)
     endif()
   endforeach()
 endif()
-
-# gets version from admin.c file
-get_ingescape_version(INGESCAPE_VERSION_MAJOR INGESCAPE_VERSION_MINOR INGESCAPE_VERSION_PATCH)
-set(INGESCAPE_VERSION "${INGESCAPE_VERSION_MAJOR}.${INGESCAPE_VERSION_MINOR}.${INGESCAPE_VERSION_PATCH}")
-message(STATUS "Detected INGESCAPE Version - ${INGESCAPE_VERSION}")
 
 
 # ##############################################################################
@@ -306,16 +306,17 @@ if (NOT DEPS_ONLY)
 
     install(TARGETS ${PROJECT_NAME}
             EXPORT ${PROJECT_NAME}-targets
+            COMPONENT library
             FRAMEWORK DESTINATION "Frameworks" # .framework file
-                    COMPONENT library
+            COMPONENT library
             PUBLIC_HEADER DESTINATION include
-                    COMPONENT library
+            COMPONENT library
             LIBRARY DESTINATION "lib${LIB_SUFFIX}" # .so file
-                    COMPONENT library
+            COMPONENT library
             ARCHIVE DESTINATION "lib${LIB_SUFFIX}" # .lib file
-                    COMPONENT library
+            COMPONENT library
             RUNTIME DESTINATION "lib${LIB_SUFFIX}" # .dll file
-                    COMPONENT library)
+            COMPONENT library)
   endif()
 
   # static
@@ -325,18 +326,18 @@ if (NOT DEPS_ONLY)
     if (WITH_DEPS)
       add_dependencies(${PROJECT_NAME}-static zyre)
 
-      target_link_libraries(${PROJECT_NAME}-static PRIVATE sodium)
-      target_link_libraries(${PROJECT_NAME}-static PRIVATE libzmq)
-      target_link_libraries(${PROJECT_NAME}-static PRIVATE czmq)
-      target_link_libraries(${PROJECT_NAME}-static PRIVATE zyre)
+      target_link_libraries(${PROJECT_NAME}-static PRIVATE sodium-static)
+      target_link_libraries(${PROJECT_NAME}-static PRIVATE libzmq-static)
+      target_link_libraries(${PROJECT_NAME}-static PRIVATE czmq-static)
+      target_link_libraries(${PROJECT_NAME}-static PRIVATE zyre-static)
     else ()
       target_link_libraries(${PROJECT_NAME}-static PRIVATE ${LIBSODIUM_LIBRARIES})
       target_include_directories(${PROJECT_NAME}-static PRIVATE ${LIBSODIUM_INCLUDE_DIRS})
-      target_link_libraries(${PROJECT_NAME}-static PRIVATE libzmq)
+      target_link_libraries(${PROJECT_NAME}-static PRIVATE libzmq-static)
       target_include_directories(${PROJECT_NAME}-static PRIVATE ${ZeroMQ_INCLUDE_DIR})
-      target_link_libraries(${PROJECT_NAME}-static PRIVATE czmq)
+      target_link_libraries(${PROJECT_NAME}-static PRIVATE czmq-static)
       target_include_directories(${PROJECT_NAME}-static PRIVATE ${CZMQ_PUBLIC_HEADERS_DIR})
-      target_link_libraries(${PROJECT_NAME}-static PRIVATE zyre)
+      target_link_libraries(${PROJECT_NAME}-static PRIVATE zyre-static)
       target_include_directories(${PROJECT_NAME}-static PRIVATE ${zyre_INCLUDES_DIR})
     endif ()
 
@@ -474,7 +475,10 @@ if (NOT DEPS_ONLY)
   # installer
   # ##############################################################################
   # Package installer for release build only
-  if((WIN32) OR (CMAKE_BUILD_TYPE STREQUAL "Release"))
+  if (${CMAKE_OS_NAME} MATCHES "Debian")
+    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake")
+    include(Packing-debian)
+  elseif((WIN32) OR (${CMAKE_BUILD_TYPE} STREQUAL "Release"))
     #https://cmake.org/cmake/help/v3.16/module/CPack.html#
     set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
     set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PROJECT_NAME} core library")

--- a/builds/cmake/Packing-debian.cmake
+++ b/builds/cmake/Packing-debian.cmake
@@ -1,0 +1,56 @@
+message(STATUS "Package configuration (only DEB for now)")
+# these are cache variables, so they could be overwritten with -D,
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-dev
+    CACHE STRING "The resulting package name"
+)
+# which is useful in case of packing only selected components instead of the whole thing
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Model-based framework for broker-free distributed software environments - development package"
+    CACHE STRING "Package description summary"
+)
+set(CPACK_PACKAGE_VENDOR "Ingescape")
+
+set(CPACK_VERBATIM_VARIABLES YES)
+
+set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
+SET(CPACK_OUTPUT_FILE_PREFIX "${CMAKE_SOURCE_DIR}/_packages")
+
+# https://unix.stackexchange.com/a/11552/254512
+set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")#/${CMAKE_PROJECT_VERSION}")
+
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+
+set(CPACK_PACKAGE_CONTACT "github@ingescape.com")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Ingenuity I/O <${CPACK_PACKAGE_CONTACT}>")
+
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
+        DESTINATION ${CPACK_PACKAGING_INSTALL_PREFIX}/share/doc/${PROJECT_NAME}-dev
+        RENAME copyright)
+
+# Strip binaries of debuging names and symbols
+set(CPACK_STRIP_FILES YES)
+
+# Set dependencies line in package control file
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+# License
+set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+
+
+# package name for deb
+# if set, then instead of some-application-0.9.2-Linux.deb
+# you'll get some-application_0.9.2_amd64.deb (note the underscores too)
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+# if you want every group to have its own package,
+# although the same happens if this is not sent (so it defaults to ONE_PER_GROUP)
+# and CPACK_DEB_COMPONENT_INSTALL is set to YES
+set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)#ONE_PER_GROUP)
+# without this you won't be able to pack only specified component
+set(CPACK_DEB_COMPONENT_INSTALL YES)
+
+message(STATUS "Components to pack: ${CPACK_COMPONENTS_ALL}")
+
+include(CPack)


### PR DESCRIPTION
**The package is not ready to be posted on Debian repository**  
It still has lintian errors and may not be validated by the Debian folks.  

Nonetheless, the package installs a complete version of the ingescape library and its dependencies.  
It can be put on a "private" repository and delivered through APT.

The package name is `ingescape-dev` so the APT command line to install the package would be `apt-get install ingescape-dev`