### PR TITLE
Problem: CMake update for Debian packaging broke previous debian jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -725,8 +725,8 @@ build-deb-package:
     - docker
   image: debian:11
   script:
-    - apt update || apt update
-    - apt install -y build-essential cmake file git tree rsync
+    - apt-get update || apt-get update
+    - apt-get install -y build-essential cmake file git tree rsync
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
     - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_COMPONENTS_ALL="Unspecified;library"
     - cmake --build b --parallel 6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,6 +100,8 @@ lib-deploy-macos:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 
 # Build/Deploy ingescape on macos-qt6 runner
@@ -134,6 +136,8 @@ lib-deploy-macos-qt6:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 
 #__          ___           _
@@ -337,6 +341,8 @@ lib-deploy-windows:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 # _      _
 #| |    (_)
@@ -409,6 +415,8 @@ lib-deploy-linux-release-x64:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 
 ##
@@ -471,6 +479,8 @@ lib-deploy-debian-qt6-x64:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 
 ##
@@ -509,6 +519,8 @@ lib-deploy-centos-qt:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 ##
 ## armhf (RPi)
@@ -574,6 +586,8 @@ lib-deploy-linux-release-armhf:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 
 ##
@@ -633,6 +647,8 @@ lib-deploy-linux-release-aarch64:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 ##
 ## armv7a (Android)
@@ -691,6 +707,8 @@ lib-deploy-linux-release-armv7a-softfp:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
 
 
 # _____       _ _
@@ -761,3 +779,5 @@ lib-delivery-all:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -742,8 +742,7 @@ build-deb-package:
     - umask 022
     - echo "Push to repo"
     - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} echo Connected
-    - cd debian_x64
-    - rsync --rsh="ssh -i ssh_secret" ingescape-dev*.deb ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
+    - rsync --rsh="ssh -i ssh_secret" debian_x64/ingescape-dev*.deb ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
     - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -742,7 +742,8 @@ build-deb-package:
     - umask 022
     - echo "Push to repo"
     - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} echo Connected
-    - rsync --rsh="ssh -i ssh_secret" --recursive library ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
+    - cd debian_x64
+    - rsync --rsh="ssh -i ssh_secret" ingescape-dev*.deb ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
     - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -725,7 +725,8 @@ build-deb-package:
     - docker
   image: debian:11
   script:
-    - apt update && apt install build-essential cmake file git
+    - apt update || apt update
+    - apt install -y build-essential cmake file git
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
     - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_COMPONENTS_ALL="Unspecified;library"
     - cmake --build b
@@ -733,7 +734,16 @@ build-deb-package:
     - (cd _packages && dpkg-deb -R ingescape-dev*.deb p && tree p)
     - mkdir debian_x64
     - mv _packages/ingescape-dev*.deb debian_x64
-    - echo "Publish to repo"
+    - echo "Setting up SSH"
+    - mkdir -p ~/.ssh/
+    - echo ${STABLE_SSH_KNOWN_HOSTS} | base64 -d >> ~/.ssh/known_hosts
+    - umask 077
+    - echo ${STABLE_SSH_SECRET} | base64 -d > ssh_secret
+    - umask 022
+    - echo "Push to repo"
+    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} echo Connected
+    #- rsync --rsh="ssh -i ssh_secret" --recursive library ${DELIVERY_USER}@${DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
+    #- ssh -i ssh_secret ${DELIVERY_USER}@${DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
   artifacts:
     paths:
       - debian_x64/ingescape-dev*.deb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -720,7 +720,7 @@ lib-deploy-linux-release-armv7a-softfp:
 
 build-deb-package:
   extends: .lib-build-files
-  stage: lib-delivery
+  stage: lib-build
   tags:
     - docker
   image: debian:11

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -726,7 +726,7 @@ build-deb-package:
   image: debian:11
   script:
     - apt update || apt update
-    - apt install -y build-essential cmake file git
+    - apt install -y build-essential cmake file git tree
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
     - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_COMPONENTS_ALL="Unspecified;library"
     - cmake --build b

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -729,7 +729,7 @@ build-deb-package:
     - apt install -y build-essential cmake file git tree rsync
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
     - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_COMPONENTS_ALL="Unspecified;library"
-    - cmake --build b
+    - cmake --build b --parallel 6
     - (cd b && cpack -G DEB)
     - (cd _packages && dpkg-deb -R ingescape-dev*.deb p && tree p)
     - mkdir debian_x64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -560,6 +560,7 @@ lib-installer-runtime-linux-armhf:
     - export INGESCAPE_MAJOR=$(grep "#define INGESCAPE_VERSION_MAJOR" include/ingescape.h | cut -d ' ' -f3-)
     - export INGESCAPE_MINOR=$(grep "#define INGESCAPE_VERSION_MINOR" include/ingescape.h | cut -d ' ' -f3-)
     - export INGESCAPE_VERSION=$INGESCAPE_MAJOR.$INGESCAPE_MINOR.$CI_PIPELINE_ID
+    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_DEPS=ON -DCI_PIPELINE_ID=${CI_PIPELINE_ID} -DPACK_TGZ=ON
     - cd build
     - make package
     - tar xf ingescape-${INGESCAPE_VERSION}-Linux.tar.gz
@@ -711,6 +712,33 @@ lib-deploy-linux-release-armv7a-softfp:
       - main
     variables:
       - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+
+
+##
+## Debian (.deb package)
+##
+
+build-deb-package:
+  extends: .lib-build-files
+  stage: lib-delivery
+  tags:
+    - docker
+  image: debian:11
+  script:
+    - apt update && apt install build-essential cmake file git
+    - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
+    - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_COMPONENTS_ALL="Unspecified;library"
+    - cmake --build b
+    - (cd b && cpack -G DEB)
+    - (cd _packages && dpkg-deb -R ingescape-dev*.deb p && tree p)
+    - mkdir debian_x64
+    - mv _packages/ingescape-dev*.deb debian_x64
+    - echo "Publish to repo"
+  artifacts:
+    paths:
+      - debian_x64/ingescape-dev*.deb
+    name: "ingescape-dev-debian-package"
+  dependencies: []
 
 
 # _____       _ _

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -720,7 +720,7 @@ lib-deploy-linux-release-armv7a-softfp:
 
 build-deb-package:
   extends: .lib-build-files
-  stage: lib-build
+  stage: lib-delivery
   tags:
     - docker
   image: debian:11

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -726,7 +726,7 @@ build-deb-package:
   image: debian:11
   script:
     - apt update || apt update
-    - apt install -y build-essential cmake file git tree
+    - apt install -y build-essential cmake file git tree rsync
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
     - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_COMPONENTS_ALL="Unspecified;library"
     - cmake --build b

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -736,7 +736,7 @@ build-deb-package:
     - mv _packages/ingescape-dev*.deb debian_x64
     - echo "Setting up SSH"
     - mkdir -p ~/.ssh/
-    - echo ${STABLE_SSH_KNOWN_HOSTS} | base64 -d >> ~/.ssh/known_hosts
+    - ssh-keyscan -t rsa ingescape.com >> ~/.ssh/known_hosts
     - umask 077
     - echo ${STABLE_SSH_SECRET} | base64 -d > ssh_secret
     - umask 022

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -742,8 +742,8 @@ build-deb-package:
     - umask 022
     - echo "Push to repo"
     - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} echo Connected
-    #- rsync --rsh="ssh -i ssh_secret" --recursive library ${DELIVERY_USER}@${DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
-    #- ssh -i ssh_secret ${DELIVERY_USER}@${DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
+    - rsync --rsh="ssh -i ssh_secret" --recursive library ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
+    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
   artifacts:
     paths:
       - debian_x64/ingescape-dev*.deb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -386,6 +386,7 @@ lib-installer-linux-x64:
     - export INGESCAPE_MAJOR=$(grep "#define INGESCAPE_VERSION_MAJOR" include/ingescape.h | cut -d ' ' -f3-)
     - export INGESCAPE_MINOR=$(grep "#define INGESCAPE_VERSION_MINOR" include/ingescape.h | cut -d ' ' -f3-)
     - export INGESCAPE_VERSION=$INGESCAPE_MAJOR.$INGESCAPE_MINOR.$CI_PIPELINE_ID
+    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_DEPS=ON -DCI_PIPELINE_ID=${CI_PIPELINE_ID} -DPACK_TGZ=ON
     - cd build
     - make package
     - tar xf ingescape-${INGESCAPE_VERSION}-Linux.tar.gz
@@ -451,6 +452,7 @@ lib-installer-debian-qt6-x64:
     - export INGESCAPE_MAJOR=$(grep "#define INGESCAPE_VERSION_MAJOR" include/ingescape.h | cut -d ' ' -f3-)
     - export INGESCAPE_MINOR=$(grep "#define INGESCAPE_VERSION_MINOR" include/ingescape.h | cut -d ' ' -f3-)
     - export INGESCAPE_VERSION=$INGESCAPE_MAJOR.$INGESCAPE_MINOR.$CI_PIPELINE_ID
+    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_DEPS=ON -DCI_PIPELINE_ID=${CI_PIPELINE_ID} -DPACK_TGZ=ON
     - cd build
     - make package
     - tar xf ingescape-${INGESCAPE_VERSION}-Linux.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,7 +475,8 @@ if (NOT DEPS_ONLY)
   # installer
   # ##############################################################################
   # Package installer for release build only
-  if (${CMAKE_OS_NAME} MATCHES "Debian")
+  option(PACK_TGZ "Force pack ingescape as a TGZ and not a .deb package" OFF)
+  if (${CMAKE_OS_NAME} MATCHES "Debian" AND NOT ${PACK_TGZ})
     set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake")
     include(Packing-debian)
   elseif((WIN32) OR (${CMAKE_BUILD_TYPE} STREQUAL "Release"))


### PR DESCRIPTION
Solution: Do not pack previous debian builds as .deb packages.

Add a publish job to send .deb package to our own APT repository