### PR TITLE
Problem: SIGSEGV occurs when trying to compare mappings with splits 

### DIFF
--- a/include/ingescape.h
+++ b/include/ingescape.h
@@ -32,7 +32,7 @@
 //  INGESCAPE version macros for compile-time API detection
 #define INGESCAPE_VERSION_MAJOR 3
 #define INGESCAPE_VERSION_MINOR 0
-#define INGESCAPE_VERSION_PATCH 1
+#define INGESCAPE_VERSION_PATCH 2
 
 #define INGESCAPE_MAKE_VERSION(major, minor, patch) \
 ((major) * 10000 + (minor) * 100 + (patch))

--- a/src/igs_mapping.c
+++ b/src/igs_mapping.c
@@ -139,7 +139,7 @@ bool mapping_is_equal (const char *first_str, const char *second_str)
     igs_split_t *elmt_split, *tmp_split, *second_elmt_split;
     HASH_ITER (hh, first->split_elements, elmt_split, tmp_split){
         second_elmt_split = NULL;
-        HASH_FIND (hh, second->split_elements, &elmt->id, sizeof (uint64_t), second_elmt_split);
+        HASH_FIND (hh, second->split_elements, &elmt_split->id, sizeof (uint64_t), second_elmt_split);
         if (!second_elmt_split) {
             res = false;
             goto END;


### PR DESCRIPTION
Solution: There was a copy/paste mistake is the `mapping_is_equal` method. Using the right variable name solved the issue.  

This PR increments the PATCH version number from 3.0.1 to 3.0.2