### PR TITLE
Problem: Packaged versions of ingescape for Debian are all stripped of the debug symbols

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,8 +100,6 @@ lib-deploy-macos:
   only:
     refs:
       - main
-    variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 # Build/Deploy ingescape on macos-qt6 runner
@@ -136,8 +134,6 @@ lib-deploy-macos-qt6:
   only:
     refs:
       - main
-    variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 #__          ___           _
@@ -341,8 +337,6 @@ lib-deploy-windows:
   only:
     refs:
       - main
-    variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 # _      _
 #| |    (_)
@@ -416,8 +410,6 @@ lib-deploy-linux-release-x64:
   only:
     refs:
       - main
-    variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 ##

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,6 +100,8 @@ lib-deploy-macos:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 # Build/Deploy ingescape on macos-qt6 runner
@@ -134,6 +136,8 @@ lib-deploy-macos-qt6:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 #__          ___           _
@@ -337,6 +341,8 @@ lib-deploy-windows:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 # _      _
 #| |    (_)
@@ -410,6 +416,8 @@ lib-deploy-linux-release-x64:
   only:
     refs:
       - main
+    variables:
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 ##

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ lib-deploy-macos:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 # Build/Deploy ingescape on macos-qt6 runner
@@ -137,7 +137,7 @@ lib-deploy-macos-qt6:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 #__          ___           _
@@ -342,7 +342,7 @@ lib-deploy-windows:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 # _      _
 #| |    (_)
@@ -417,7 +417,7 @@ lib-deploy-linux-release-x64:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 ##
@@ -482,7 +482,7 @@ lib-deploy-debian-qt6-x64:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 ##
@@ -522,7 +522,7 @@ lib-deploy-centos-qt:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 ##
 ## armhf (RPi)
@@ -590,7 +590,7 @@ lib-deploy-linux-release-armhf:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 ##
@@ -651,7 +651,7 @@ lib-deploy-linux-release-aarch64:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 ##
 ## armv7a (Android)
@@ -711,7 +711,7 @@ lib-deploy-linux-release-armv7a-softfp:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"
 
 
 ##
@@ -748,6 +748,71 @@ build-deb-package:
     paths:
       - debian_x64/ingescape-dev*.deb
     name: "ingescape-dev-debian-package"
+  dependencies: []
+
+build-no-strip-deb-package:
+  extends: .lib-build-files
+  stage: lib-delivery
+  tags:
+    - docker
+  image: debian:11
+  script:
+    - apt-get update || apt-get update
+    - apt-get install -y build-essential cmake file git tree rsync
+    - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
+    - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DDEB_NO_STRIP=ON -DCPACK_COMPONENTS_ALL="Unspecified;library"
+    - cmake --build b --parallel 6
+    - (cd b && cpack -G DEB)
+    - (cd _packages && dpkg-deb -R ingescape-no-strip-dev*.deb p && tree p)
+    - mkdir debian_x64
+    - mv _packages/ingescape-no-strip-dev*.deb debian_x64
+    - echo "Setting up SSH"
+    - mkdir -p ~/.ssh/
+    - ssh-keyscan -t rsa ingescape.com >> ~/.ssh/known_hosts
+    - umask 077
+    - echo ${STABLE_SSH_SECRET} | base64 -d > ssh_secret
+    - umask 022
+    - echo "Push to repo"
+    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} echo Connected
+    - rsync --rsh="ssh -i ssh_secret" debian_x64/ingescape-no-strip-dev*.deb ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
+    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
+  artifacts:
+    paths:
+      - debian_x64/ingescape-no-strip-dev*.deb
+    name: "ingescape-no-strip-dev-debian-package"
+  dependencies: []
+
+
+build-debug-deb-package:
+  extends: .lib-build-files
+  stage: lib-delivery
+  tags:
+    - docker
+  image: debian:11
+  script:
+    - apt-get update || apt-get update
+    - apt-get install -y build-essential cmake file git tree rsync
+    - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
+    - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Debug -DCPACK_COMPONENTS_ALL="Unspecified;library"
+    - cmake --build b --parallel 6
+    - (cd b && cpack -G DEB)
+    - (cd _packages && dpkg-deb -R ingescape-debug-dev*.deb p && tree p)
+    - mkdir debian_x64
+    - mv _packages/ingescape-debug-dev*.deb debian_x64
+    - echo "Setting up SSH"
+    - mkdir -p ~/.ssh/
+    - ssh-keyscan -t rsa ingescape.com >> ~/.ssh/known_hosts
+    - umask 077
+    - echo ${STABLE_SSH_SECRET} | base64 -d > ssh_secret
+    - umask 022
+    - echo "Push to repo"
+    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} echo Connected
+    - rsync --rsh="ssh -i ssh_secret" debian_x64/ingescape-debug-dev*.deb ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
+    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
+  artifacts:
+    paths:
+      - debian_x64/ingescape-debug-dev*.deb
+    name: "ingescape-debug-dev-debian-package"
   dependencies: []
 
 
@@ -820,4 +885,4 @@ lib-delivery-all:
     refs:
       - main
     variables:
-      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape"
+      - $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private"

--- a/builds/cmake/Packing-debian.cmake
+++ b/builds/cmake/Packing-debian.cmake
@@ -5,14 +5,17 @@ option(DEB_NO_STRIP "Do not strip binaries when generating the .deb package" OFF
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     message(STATUS "Debug build, binaries with debug symbols will be used for .deb package")
     set(CPACK_PACKAGE_NAME ${BASE_PACKAGE_NAME}-debug-dev CACHE STRING "The resulting package name")
+    set(CPACK_DEBIAN_PACKAGE_CONFLICTS "${BASE_PACKAGE_NAME}-dev, ${BASE_PACKAGE_NAME}-no-strip-dev")
 elseif (${DEB_NO_STRIP})
     message(STATUS "DEB_NO_STRIP activated, binaries won't be stripped of symbols when generating the .deb package")
     set(CPACK_PACKAGE_NAME ${BASE_PACKAGE_NAME}-no-strip-dev CACHE STRING "The resulting package name")
+    set(CPACK_DEBIAN_PACKAGE_CONFLICTS "${BASE_PACKAGE_NAME}-dev, ${BASE_PACKAGE_NAME}-debug-dev")
 else()
     message(STATUS "Binaries will be stripped of debug symbols.")
     message(STATUS "  Set -DCMAKE_BUILD_TYPE=Debug to create a package with debug symbols.")
     message(STATUS "  Set -DDEB_NO_STRIP=ON to have release binaries not stripped when generating the .deb package.")
     set(CPACK_PACKAGE_NAME ${BASE_PACKAGE_NAME}-dev CACHE STRING "The resulting package name")
+    set(CPACK_DEBIAN_PACKAGE_CONFLICTS "${BASE_PACKAGE_NAME}-debug-dev, ${BASE_PACKAGE_NAME}-no-strip-dev")
 endif()
 
 # which is useful in case of packing only selected components instead of the whole thing

--- a/builds/cmake/Packing-debian.cmake
+++ b/builds/cmake/Packing-debian.cmake
@@ -1,12 +1,20 @@
 message(STATUS "Package configuration (only DEB for now)")
+option(DEB_NO_STRIP "Do not strip binaries when generating the .deb package" OFF)
 # these are cache variables, so they could be overwritten with -D,
-set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-dev
-    CACHE STRING "The resulting package name"
-)
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    message(STATUS "Debug build, binaries with debug symbols will be used for .deb package")
+    set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-debug-dev CACHE STRING "The resulting package name")
+else (${DEB_NO_STRIP})
+    message(STATUS "DEB_NO_STRIP activated, binaries won't be stripped of symbols when generating the .deb package")
+    set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-no-strip-dev CACHE STRING "The resulting package name")
+else()
+    message(STATUS "Binaries will be stripped of debug symbols.")
+    message(STATUS "  Set -DCMAKE_BUILD_TYPE=Debug to create a package with debug symbols.")
+    message(STATUS "  Set -DDEB_NO_STRIP=ON to have release binaries not stripped when generating the .deb package.")
+    set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-dev CACHE STRING "The resulting package name")
+endif()
 # which is useful in case of packing only selected components instead of the whole thing
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Model-based framework for broker-free distributed software environments - development package"
-    CACHE STRING "Package description summary"
-)
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Model-based framework for broker-free distributed software environments - development package" CACHE STRING "Package description summary")
 set(CPACK_PACKAGE_VENDOR "Ingescape")
 
 set(CPACK_VERBATIM_VARIABLES YES)
@@ -30,8 +38,15 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
         DESTINATION ${CPACK_PACKAGING_INSTALL_PREFIX}/share/doc/${PROJECT_NAME}-dev
         RENAME copyright)
 
+
 # Strip binaries of debuging names and symbols
-set(CPACK_STRIP_FILES YES)
+if ((${CMAKE_BUILD_TYPE} STREQUAL "Debug") OR ${DEB_NO_STRIP})
+    message(STATUS "Binaries will NOT be stripped when generating .deb package")
+    set(CPACK_STRIP_FILES NO)
+else()
+    message(STATUS "Binaries will be stripped when generating .deb package")
+    set(CPACK_STRIP_FILES YES)
+endif()
 
 # Set dependencies line in package control file
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)

--- a/builds/cmake/Packing-debian.cmake
+++ b/builds/cmake/Packing-debian.cmake
@@ -1,18 +1,20 @@
 message(STATUS "Package configuration (only DEB for now)")
+set(BASE_PACKAGE_NAME ${PROJECT_NAME})
 option(DEB_NO_STRIP "Do not strip binaries when generating the .deb package" OFF)
 # these are cache variables, so they could be overwritten with -D,
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     message(STATUS "Debug build, binaries with debug symbols will be used for .deb package")
-    set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-debug-dev CACHE STRING "The resulting package name")
+    set(CPACK_PACKAGE_NAME ${BASE_PACKAGE_NAME}-debug-dev CACHE STRING "The resulting package name")
 elseif (${DEB_NO_STRIP})
     message(STATUS "DEB_NO_STRIP activated, binaries won't be stripped of symbols when generating the .deb package")
-    set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-no-strip-dev CACHE STRING "The resulting package name")
+    set(CPACK_PACKAGE_NAME ${BASE_PACKAGE_NAME}-no-strip-dev CACHE STRING "The resulting package name")
 else()
     message(STATUS "Binaries will be stripped of debug symbols.")
     message(STATUS "  Set -DCMAKE_BUILD_TYPE=Debug to create a package with debug symbols.")
     message(STATUS "  Set -DDEB_NO_STRIP=ON to have release binaries not stripped when generating the .deb package.")
-    set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-dev CACHE STRING "The resulting package name")
+    set(CPACK_PACKAGE_NAME ${BASE_PACKAGE_NAME}-dev CACHE STRING "The resulting package name")
 endif()
+
 # which is useful in case of packing only selected components instead of the whole thing
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Model-based framework for broker-free distributed software environments - development package" CACHE STRING "Package description summary")
 set(CPACK_PACKAGE_VENDOR "Ingescape")
@@ -35,7 +37,7 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Ingenuity I/O <${CPACK_PACKAGE_CONTACT}>")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
-        DESTINATION ${CPACK_PACKAGING_INSTALL_PREFIX}/share/doc/${PROJECT_NAME}-dev
+        DESTINATION ${CPACK_PACKAGING_INSTALL_PREFIX}/share/doc/${CPACK_PACKAGE_NAME}
         RENAME copyright)
 
 

--- a/builds/cmake/Packing-debian.cmake
+++ b/builds/cmake/Packing-debian.cmake
@@ -4,7 +4,7 @@ option(DEB_NO_STRIP "Do not strip binaries when generating the .deb package" OFF
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     message(STATUS "Debug build, binaries with debug symbols will be used for .deb package")
     set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-debug-dev CACHE STRING "The resulting package name")
-else (${DEB_NO_STRIP})
+elseif (${DEB_NO_STRIP})
     message(STATUS "DEB_NO_STRIP activated, binaries won't be stripped of symbols when generating the .deb package")
     set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-no-strip-dev CACHE STRING "The resulting package name")
 else()


### PR DESCRIPTION
Solution: Generate multiple packages.

- One stripped, called `ingescape-dev`
- One in Release mode with symbols, called `ingescape-no-strip-dev`
- One in Debug mode with all the symbols and without optimization, called `ingescape-debug-dev`

The PR also includes a fix to trigger jobs on our private pipelines