### PR TITLE
Problem: .deb packages built on Debian 11 have compatibility issues with older Debian

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -718,22 +718,37 @@ lib-deploy-linux-release-armv7a-softfp:
 ## Debian (.deb package)
 ##
 
-build-deb-package:
+build-deb-packages:
   extends: .lib-build-files
   stage: lib-delivery
   tags:
     - docker
-  image: debian:11
+  image: debian:10
   script:
     - apt-get update || apt-get update
-    - apt-get install -y build-essential cmake file git tree rsync
+    - apt-get install -y build-essential file git tree rsync wget libssl-dev libcurl4-openssl-dev
+    - wget -qO- https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz | tar xfz -
+    - (cd cmake-3.22.2 ; ./bootstrap && make -j6 && make install)
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
+    - mkdir debian_x64
+    - echo "Release build"
     - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_COMPONENTS_ALL="Unspecified;library"
     - cmake --build b --parallel 6
     - (cd b && cpack -G DEB)
-    - (cd _packages && dpkg-deb -R ingescape-dev*.deb p && tree p)
-    - mkdir debian_x64
+    - (cd _packages && dpkg-deb -R ingescape-dev*.deb p && tree p && rm -rf p)
     - mv _packages/ingescape-dev*.deb debian_x64
+    - echo "Release build -no-strip"
+    - cmake -S . -B b_no_strip -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DDEB_NO_STRIP=ON -DCPACK_COMPONENTS_ALL="Unspecified;library"
+    - cmake --build b_no_strip --parallel 6
+    - (cd b_no_strip && cpack -G DEB)
+    - (cd _packages && dpkg-deb -R ingescape-no-strip-dev*.deb p && tree p && rm -rf p)
+    - mv _packages/ingescape-no-strip-dev*.deb debian_x64
+    - echo "Debug build"
+    - cmake -S . -B b_debug -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Debug -DCPACK_COMPONENTS_ALL="Unspecified;library"
+    - cmake --build b_debug --parallel 6
+    - (cd b_debug && cpack -G DEB)
+    - (cd _packages && dpkg-deb -R ingescape-debug-dev*.deb p && tree p && rm -rf p)
+    - mv _packages/ingescape-debug-dev*.deb debian_x64
     - echo "Setting up SSH"
     - mkdir -p ~/.ssh/
     - ssh-keyscan -t rsa ingescape.com >> ~/.ssh/known_hosts
@@ -746,73 +761,8 @@ build-deb-package:
     - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
   artifacts:
     paths:
-      - debian_x64/ingescape-dev*.deb
+      - debian_x64/ingescape*.deb
     name: "ingescape-dev-debian-package"
-  dependencies: []
-
-build-no-strip-deb-package:
-  extends: .lib-build-files
-  stage: lib-delivery
-  tags:
-    - docker
-  image: debian:11
-  script:
-    - apt-get update || apt-get update
-    - apt-get install -y build-essential cmake file git tree rsync
-    - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
-    - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DDEB_NO_STRIP=ON -DCPACK_COMPONENTS_ALL="Unspecified;library"
-    - cmake --build b --parallel 6
-    - (cd b && cpack -G DEB)
-    - (cd _packages && dpkg-deb -R ingescape-no-strip-dev*.deb p && tree p)
-    - mkdir debian_x64
-    - mv _packages/ingescape-no-strip-dev*.deb debian_x64
-    - echo "Setting up SSH"
-    - mkdir -p ~/.ssh/
-    - ssh-keyscan -t rsa ingescape.com >> ~/.ssh/known_hosts
-    - umask 077
-    - echo ${STABLE_SSH_SECRET} | base64 -d > ssh_secret
-    - umask 022
-    - echo "Push to repo"
-    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} echo Connected
-    - rsync --rsh="ssh -i ssh_secret" debian_x64/ingescape-no-strip-dev*.deb ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
-    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
-  artifacts:
-    paths:
-      - debian_x64/ingescape-no-strip-dev*.deb
-    name: "ingescape-no-strip-dev-debian-package"
-  dependencies: []
-
-
-build-debug-deb-package:
-  extends: .lib-build-files
-  stage: lib-delivery
-  tags:
-    - docker
-  image: debian:11
-  script:
-    - apt-get update || apt-get update
-    - apt-get install -y build-essential cmake file git tree rsync
-    - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
-    - cmake -S . -B b -DWITH_DEPS=ON -DCMAKE_BUILD_TYPE=Debug -DCPACK_COMPONENTS_ALL="Unspecified;library"
-    - cmake --build b --parallel 6
-    - (cd b && cpack -G DEB)
-    - (cd _packages && dpkg-deb -R ingescape-debug-dev*.deb p && tree p)
-    - mkdir debian_x64
-    - mv _packages/ingescape-debug-dev*.deb debian_x64
-    - echo "Setting up SSH"
-    - mkdir -p ~/.ssh/
-    - ssh-keyscan -t rsa ingescape.com >> ~/.ssh/known_hosts
-    - umask 077
-    - echo ${STABLE_SSH_SECRET} | base64 -d > ssh_secret
-    - umask 022
-    - echo "Push to repo"
-    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} echo Connected
-    - rsync --rsh="ssh -i ssh_secret" debian_x64/ingescape-debug-dev*.deb ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST}:/home/ingescape/domains/repository.ingescape.com/public_html/debian/pool/main
-    - ssh -i ssh_secret ${STABLE_DELIVERY_USER}@${STABLE_DELIVERY_HOST} /home/ingescape/domains/repository.ingescape.com/refresh_deb_repo.sh
-  artifacts:
-    paths:
-      - debian_x64/ingescape-debug-dev*.deb
-    name: "ingescape-debug-dev-debian-package"
   dependencies: []
 
 


### PR DESCRIPTION
Solution: Build .deb packages on Debian old stable (currently Debian 10 buster)