### PR TITLE
Problem: Static lib names on Windows do not follow the same patterns as other ZeroMQ projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,8 +351,8 @@ if (NOT DEPS_ONLY)
 
       set_target_properties(${PROJECT_NAME}-static
                               PROPERTIES
-                                OUTPUT_NAME_RELEASE "ingescape_static"
-                                OUTPUT_NAME_DEBUG "ingescaped_static")
+                                OUTPUT_NAME_RELEASE "libingescape"
+                                OUTPUT_NAME_DEBUG "libingescaped")
 
     else(MSVC)
       set_target_properties(${PROJECT_NAME}-static


### PR DESCRIPTION
Solution: Renaming

The pattern is:
 * <lib_name>.lib/<lib_name>.dll => dynamic library
 * lib<lib_name>.lib => static library

For ingescape:
 * ingescape.lib/ingescape.dll => dynamic library
 * libingescape.lib => static library