### PR TITLE
Problem: Bindings cannot link against static version of the library because of position dependent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ ADD_DEFINITIONS (-DZYRE_BUILD_DRAFT_API)
 ADD_DEFINITIONS (-DCZMQ_BUILD_DRAFT_API)
 ADD_DEFINITIONS (-DZMQ_BUILD_DRAFT_API)
 
+# Define the PIC compilation flag
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Option to only generate dependencies.
 # Used to setup developmenent environment.
 option(DEPS_ONLY "Only generate dependencies" OFF)


### PR DESCRIPTION
Solution: Make static library build with position independent code using the -fPIC flag.

CMake provides an easy way to do this with `set(CMAKE_POSITION_INDEPENDENT_CODE ON)`