### PR TITLE
Merge PUBLIC and INGESCAPE_EXPORT macros to have a single DLL export macro 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ if (NOT DEPS_ONLY)
     endif(MSVC)
 
     # Add compilation #defines to the target
-    target_compile_definitions(${PROJECT_NAME} PRIVATE INGESCAPE=1;TARGET_OS_IOS=0)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE INGESCAPE_EXPORTS=1;TARGET_OS_IOS=0)
 
     # Add linked dependencies
     #FIXME All private here ?
@@ -365,7 +365,7 @@ if (NOT DEPS_ONLY)
     endif(MSVC)
 
     # Add compilation #defines to the target
-    target_compile_definitions(${PROJECT_NAME}-static PRIVATE INGESCAPE=1;TARGET_OS_IOS=0)
+    target_compile_definitions(${PROJECT_NAME}-static PRIVATE INGESCAPE_EXPORTS=1;TARGET_OS_IOS=0)
 
     # Add linked dependencies
     #FIXME All private here ?

--- a/builds/qt/ingescape.pro
+++ b/builds/qt/ingescape.pro
@@ -9,7 +9,7 @@ TARGET = ingescape
 TEMPLATE = lib
 CONFIG += plugin
 
-DEFINES += INGESCAPE
+DEFINES += INGESCAPE_EXPORTS
 
 win32:{
     DEFINES +=  _CRT_SECURE_NO_WARNINGS \
@@ -30,4 +30,3 @@ RCC_DIR = tmp
 #include ('ingescape-dev.pri')
 
 include('ingescape.pri')
-

--- a/include/igsagent.h
+++ b/include/igsagent.h
@@ -24,16 +24,16 @@ extern "C" {
 
 ////////////////////////////////////////
 // Agent creation/destruction/activation
-PUBLIC igsagent_t * igsagent_new(const char *name, bool activate_immediately);
-PUBLIC void igsagent_destroy(igsagent_t **agent);
-PUBLIC igs_result_t igsagent_activate(igsagent_t *agent);
-PUBLIC igs_result_t igsagent_deactivate(igsagent_t *agent);
-PUBLIC bool igsagent_is_activated(igsagent_t *agent);
+INGESCAPE_EXPORT igsagent_t * igsagent_new(const char *name, bool activate_immediately);
+INGESCAPE_EXPORT void igsagent_destroy(igsagent_t **agent);
+INGESCAPE_EXPORT igs_result_t igsagent_activate(igsagent_t *agent);
+INGESCAPE_EXPORT igs_result_t igsagent_deactivate(igsagent_t *agent);
+INGESCAPE_EXPORT bool igsagent_is_activated(igsagent_t *agent);
 
 typedef void (igsagent_fn)(igsagent_t *agent,
                            bool is_activated,
                            void *my_data);
-PUBLIC void igsagent_observe(igsagent_t *agent, igsagent_fn cb, void *my_data);
+INGESCAPE_EXPORT void igsagent_observe(igsagent_t *agent, igsagent_fn cb, void *my_data);
 
 
 ////////////////

--- a/include/ingescape.h
+++ b/include/ingescape.h
@@ -1,9 +1,9 @@
 /*  =========================================================================
  ingescape - public library header
- 
+
  Copyright (c) the Contributors as noted in the AUTHORS file.
  This file is part of Ingescape, see https://github.com/zeromq/ingescape.
- 
+
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -40,7 +40,9 @@
 INGESCAPE_MAKE_VERSION(INGESCAPE_VERSION_MAJOR, INGESCAPE_VERSION_MINOR, INGESCAPE_VERSION_PATCH)
 
 #if defined (__WINDOWS__)
-#   if defined INGESCAPE_STATIC
+#   if defined INGESCAPE_FROM_PRI
+#       define INGESCAPE_EXPORT
+#   elif defined INGESCAPE_STATIC
 #       define INGESCAPE_EXPORT
 #   elif defined INGESCAPE_INTERNAL_BUILD
 #       if defined DLL_EXPORT
@@ -65,18 +67,6 @@ INGESCAPE_MAKE_VERSION(INGESCAPE_VERSION_MAJOR, INGESCAPE_VERSION_MINOR, INGESCA
 #       define INGESCAPE_PRIVATE
 #       define INGESCAPE_EXPORT
 #   endif
-#endif
-
-#if defined (__WINDOWS__)
-#if defined INGESCAPE
-#define PUBLIC __declspec(dllexport)
-#elif defined INGESCAPE_FROM_PRI
-#define PUBLIC
-#else
-#define PUBLIC __declspec(dllimport)
-#endif
-#else
-#define PUBLIC
 #endif
 
 // GCC and clang can validate format strings for functions that act like printf
@@ -136,10 +126,10 @@ INGESCAPE_EXPORT bool igs_is_started(void);
  or from the network. When ingescape is stopped from the network,
  the application can be notified and take actions such as
  stopping, entering a specific mode, etc.
- 
+
  To stop ingescape from its hosting application,
  just call igs_stop().
- 
+
  To be notified that Ingescape has been stopped,you can:
  - read the pipe to ingescape and expect a "LOOP_STOPPED" message
  - register a callabck with igs_observe_forced_stop. WARNING: this
@@ -344,7 +334,7 @@ INGESCAPE_EXPORT igs_result_t igs_parameter_set_data(const char *name, void *val
  Strings
     - "~ regular_expression", e.g. "~ \\d+(\.\\d+)?)":
         IOP of type STRING must match the regular expression
- 
+
  Regular expressions are absed on CZMQ integration of SLRE with the
  following syntax:
 ^               Match beginning of a buffer
@@ -365,7 +355,7 @@ $               Match end of a buffer
 ?               Match zero or once
 \xDD            Match byte with hex value 0xDD
 \meta           Match one of the meta character: ^$().[*+?\
- 
+
  */
 INGESCAPE_EXPORT void igs_constraints_enforce(bool enforce); //default is false, i.e. disabled
 INGESCAPE_EXPORT igs_result_t igs_input_add_constraint(const char *name, const char *constraint);
@@ -587,11 +577,11 @@ INGESCAPE_EXPORT igs_result_t igs_peer_remove_header(const char *key);
  using TCP connections. Any agent can be a broker and agents using brokers
  simply have to use a list of broker endpoints. One broker is enough but
  several brokers can be set for robustness.
- 
+
  For clarity, it is better if brokers are well identified on your platform,
  started before any agent, and serve only as brokers. But any other architecture
  is permitted and brokers can be restarted at any time.
- 
+
  Endpoints have the form tcp://ip_address:port
  • igs_brokers_add is used to add brokers to connect to. Add
  as many brokers as you want. At least one declared broker is necessary to
@@ -631,7 +621,7 @@ INGESCAPE_EXPORT igs_result_t igs_start_with_brokers(const char *agent_endpoint)
  party can join a platform without providing an identity that is well-known by the other
  agents using public certificates. This is safer but requires securing private certificates
  individually and sharing public certificates between all agents.
- 
+
  Security is enabled by calling igs_enable_security.
  • If private_certificate_file is NULL, our private certificate is generated on the fly, and
  any agent with security enabled will be able to connect to us. Any value provided for
@@ -843,7 +833,7 @@ INGESCAPE_EXPORT void igs_clear_context(void);
 /* LOGS REPLAY
  Ingescape logs contain all the necessary information for an agent to replay
  its changes for inputs, outputs, parameters and services.
- 
+
  Replay happens in a dedicated thread created after calling igs_replay_init:
  • log_file_path : path to the log file to be read
  • speed : replay speed. Default is zero, meaning as fast as possible.
@@ -853,7 +843,7 @@ INGESCAPE_EXPORT void igs_clear_context(void);
  • replay_mode : a boolean composition of igs_replay_mode_t value to decide what shall be replayed.
  If mode is zero, all IOP and services are replayed.
  • agent : an OPTIONAL agent name serving as filter when the logs contain activity for multiple agents.
- 
+
  igs_replay_terminate cleans the thread and requires calling igs_replay_init again.
  Replay thread is cleaned automatically also when the log file has been read completely.
  NB: replay is still under heavy development, use at your own risk...*/
@@ -863,7 +853,7 @@ typedef enum {
     IGS_REPLAY_PARAMETER = 4,
     IGS_REPLAY_EXECUTE_SERVICE= 8,
     IGS_REPLAY_CALL_SERVICE = 16
-    
+
 } igs_replay_mode_t;
 INGESCAPE_EXPORT void igs_replay_init(const char *log_file_path,
                                       size_t speed,

--- a/include/ingescape_private.h
+++ b/include/ingescape_private.h
@@ -13,18 +13,6 @@
 #ifndef ingescape_private_h
 #define ingescape_private_h
 
-#if defined (__WINDOWS__)
-#if defined INGESCAPE
-#define PUBLIC __declspec(dllexport)
-#elif defined INGESCAPE_FROM_PRI
-#define PUBLIC
-#else
-#define PUBLIC __declspec(dllimport)
-#endif
-#else
-#define PUBLIC
-#endif
-
 #include <stdbool.h>
 #include <string.h>
 #include <zyre.h>
@@ -328,7 +316,7 @@ typedef struct igs_agent_event_wrapper {
 struct _igsagent_t {
     char *uuid;
     char *state;
-    
+
     /*
      The concept of virtual agent is used by igs_proxy. Virtual
      agents represent n existing agent which is executed somewhere
@@ -337,33 +325,33 @@ struct _igsagent_t {
      all represented inside the same igs_proxy instance).
      */
     bool is_virtual;
-    
+
     igs_core_context_t *context;
     char *igs_channel;
-    
+
     igsagent_wrapper_t *activate_callbacks;
     igs_agent_event_wrapper_t *agent_event_callbacks;
     bool enforce_constraints;
-    
+
     // definition
     char *definition_path;
     igs_definition_t* definition;
-    
+
     // mapping
     char *mapping_path;
     igs_mapping_t *mapping;
-    
+
     //network
     bool network_need_to_send_definition_update;
     bool network_need_to_send_mapping_update;
     bool network_request_outputs_from_mapped_agents;
     bool network_activation_during_runtime;
-    
+
     bool is_whole_agent_muted;
     igs_mute_wrapper_t *mute_callbacks;
-    
+
     zlist_t *elections;
-    
+
     UT_hash_handle hh;
 };
 
@@ -372,14 +360,14 @@ struct _igsagent_t {
  a set of agents at a process level.
  */
 typedef struct igs_core_context {
-    
+
     ////////////////////////////////////////////
     // persisting data with setters and getters or
     // managed automatically
     //
     // channels
     igs_peer_header_t *peer_headers;
-    
+
     // admin
     FILE *log_file;
     bool log_in_stream;
@@ -393,7 +381,7 @@ typedef struct igs_core_context {
     size_t log_file_max_line_length;
     char log_file_path[IGS_MAX_PATH_LENGTH];
     int log_nb_of_entries; //for fflush rotation
-    
+
     // network
     bool network_allow_ipc;
     bool network_allow_inproc;
@@ -411,33 +399,33 @@ typedef struct igs_core_context {
     zhash_t *brokers;
     char *advertised_endpoint;
     char *our_broker_endpoint;
-    
+
     // security
     bool security_is_enabled;
     zactor_t *security_auth;
     zcert_t *security_cert;
     char *security_public_certificates_directory;
-    
+
     // performance
     size_t performance_msg_counter;
     size_t performance_msg_count_target;
     size_t performance_msg_size;
     int64_t performance_start;
     int64_t performance_stop;
-    
+
     // network monitor
     igs_monitor_t *monitor;
     igs_monitor_wrapper_t *monitor_callbacks;
     bool monitor_shall_start_stop_agent;
-    
+
     // elections
     zhash_t *elections;
-    
+
     // initiated at start, cleaned at stop
     char *network_device;
     char *ip_address;
     char *our_agent_endpoint;
-    
+
     // initiated at s_init_loop, cleaned at loop stop
     char *command_line;
     char *replay_channel;
@@ -459,7 +447,7 @@ typedef struct igs_core_context {
     zsock_t *inproc_publisher;
     zsock_t *logger;
     zloop_t *loop;
-    
+
 } igs_core_context_t;
 
 
@@ -467,21 +455,21 @@ typedef struct igs_core_context {
 //////////////////  SHARED FUNCTIONS  AND  VARIABLES //////////////////
 
 // default context and agent
-PUBLIC extern igs_core_context_t *core_context;
-PUBLIC extern igsagent_t *core_agent;
+INGESCAPE_EXPORT extern igs_core_context_t *core_context;
+INGESCAPE_EXPORT extern igsagent_t *core_agent;
 void core_init_agent(void);
 void core_init_context(void);
 
 // definition
-PUBLIC void definition_free_definition (igs_definition_t **definition);
-PUBLIC void definition_free_constraint (igs_constraint_t **constraint);
+INGESCAPE_EXPORT void definition_free_definition (igs_definition_t **definition);
+INGESCAPE_EXPORT void definition_free_constraint (igs_constraint_t **constraint);
 
 // mapping
-PUBLIC void mapping_free_mapping (igs_mapping_t **map);
+INGESCAPE_EXPORT void mapping_free_mapping (igs_mapping_t **map);
 igs_map_t* mapping_create_mapping_element(const char * from_input,
                                           const char *to_agent,
                                           const char* to_output);
-PUBLIC bool mapping_is_equal(const char *first_str, const char *second_str);
+INGESCAPE_EXPORT bool mapping_is_equal(const char *first_str, const char *second_str);
 
 uint64_t s_djb2_hash (unsigned char *str);
 bool mapping_check_input_output_compatibility(igsagent_t *agent, igs_iop_t *found_input, igs_iop_t *found_output);
@@ -513,15 +501,15 @@ igs_constraint_t* s_model_parse_constraint(igs_iop_value_type_t type,
 igs_result_t network_publish_output (igsagent_t *agent, const igs_iop_t *iop);
 
 // parser
-PUBLIC igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json);
-PUBLIC igs_definition_t* parser_load_definition (const char* json_str);
-PUBLIC igs_definition_t* parser_load_definition_from_path (const char* file_path);
-PUBLIC char* parser_export_definition(igs_definition_t* def);
-PUBLIC char* parser_export_definition_legacy(igs_definition_t* def);
-PUBLIC char* parser_export_mapping(igs_mapping_t* mapping);
-PUBLIC char* parser_export_mapping_legacy(igs_mapping_t* mapping);
-PUBLIC igs_mapping_t* parser_load_mapping (const char* json_str);
-PUBLIC igs_mapping_t* parser_load_mapping_from_path (const char* load_file);
+INGESCAPE_EXPORT igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json);
+INGESCAPE_EXPORT igs_definition_t* parser_load_definition (const char* json_str);
+INGESCAPE_EXPORT igs_definition_t* parser_load_definition_from_path (const char* file_path);
+INGESCAPE_EXPORT char* parser_export_definition(igs_definition_t* def);
+INGESCAPE_EXPORT char* parser_export_definition_legacy(igs_definition_t* def);
+INGESCAPE_EXPORT char* parser_export_mapping(igs_mapping_t* mapping);
+INGESCAPE_EXPORT char* parser_export_mapping_legacy(igs_mapping_t* mapping);
+INGESCAPE_EXPORT igs_mapping_t* parser_load_mapping (const char* json_str);
+INGESCAPE_EXPORT igs_mapping_t* parser_load_mapping_from_path (const char* load_file);
 
 // admin
 void s_admin_make_file_path(const char *from, char *to, size_t size_of_to);
@@ -533,7 +521,7 @@ void s_unlock_zyre_peer(void);
 
 // service
 void service_free_service(igs_service_t *t);
-PUBLIC igs_result_t service_add_values_to_arguments_from_message(const char *name, igs_service_arg_t *arg, zmsg_t *msg);
+INGESCAPE_EXPORT igs_result_t service_add_values_to_arguments_from_message(const char *name, igs_service_arg_t *arg, zmsg_t *msg);
 igs_result_t service_copy_arguments(igs_service_arg_t *source, igs_service_arg_t *destination);
 void service_free_values_in_arguments(igs_service_arg_t *arg);
 void service_log_received_service(igsagent_t *agent, const char *caller_agent_name, const char *caller_agentuuid,


### PR DESCRIPTION
Both these macros help with `__declspec` declaration for API exports in Windows DLLs.

Previous `PUBLIC` macro was used in the code and never retired when fitting the project for ZeroMQ.
Then we had both `PUBLIC` and `INGESCAPE_EXPORT` macros for similar behaviors. Both used in the code.  

This PR retires the `PUBLIC` macro and replaces its previous uses with the `INGESCAPE_EXPORT` macro.