### PR TITLE
Fix default agent created even if not needed. resolve #25

### DIFF
--- a/include/ingescape_private.h
+++ b/include/ingescape_private.h
@@ -399,6 +399,7 @@ typedef struct igs_core_context {
     zhash_t *brokers;
     char *advertised_endpoint;
     char *our_broker_endpoint;
+    char *platform_name;
 
     // security
     bool security_is_enabled;
@@ -514,7 +515,7 @@ INGESCAPE_EXPORT igs_mapping_t* parser_load_mapping_from_path (const char* load_
 
 // admin
 void s_admin_make_file_path(const char *from, char *to, size_t size_of_to);
-void admin_log(igsagent_t *agent, igs_log_level_t, const char *function, const char *format, ...)  CHECK_PRINTF (4);
+void admin_log(const char *agent_name, igs_log_level_t, const char *function, const char *format, ...)  CHECK_PRINTF (4);
 
 // channels
 #define IGS_ZYRE_PEER_MUTEX_DEBUG 0

--- a/src/igs_admin.c
+++ b/src/igs_admin.c
@@ -82,13 +82,13 @@ int igs_protocol (void)
     return INGESCAPE_PROTOCOL;
 }
 
-void admin_log (igsagent_t *agent,
+void admin_log (const char *agent_name,
                 igs_log_level_t level,
                 const char *function,
                 const char *fmt,
                 ...)
 {
-    assert (agent);
+    assert (agent_name);
     assert (function);
     assert (fmt);
 
@@ -131,7 +131,7 @@ void admin_log (igsagent_t *agent,
     
     if (core_context->log_in_stream && core_context->logger)
         zstr_sendf (core_context->logger, "%s;%s;%s;%s\n",
-                    agent->definition->name, log_levels[level], function,
+                    agent_name, log_levels[level], function,
                     full_log_content_rectified);
     
     if (core_context->log_in_file && level >= core_context->log_file_level) {
@@ -152,7 +152,7 @@ void admin_log (igsagent_t *agent,
                     printf ("error while creating log dir %s\n",
                             core_context->log_file_path);
             }
-            strncat (core_context->log_file_path, agent->definition->name,
+            strncat (core_context->log_file_path, agent_name,
                      IGS_MAX_PATH_LENGTH);
             strncat (core_context->log_file_path, ".log", IGS_MAX_PATH_LENGTH);
             printf ("using log file %s\n", core_context->log_file_path);
@@ -195,7 +195,7 @@ void admin_log (igsagent_t *agent,
                       tm->tm_min, tm->tm_sec, (int) tick.tv_usec);
 #endif
             if (fprintf (core_context->log_file, "%s;%s;%s;%s;%s\n",
-                         agent->definition->name, log_time, log_levels[level],
+                         agent_name, log_time, log_levels[level],
                          function, full_log_content_rectified)
                 > 0) {
                 if (++core_context->log_nb_of_entries
@@ -218,19 +218,19 @@ void admin_log (igsagent_t *agent,
         if (level >= IGS_LOG_WARN) {
             if (core_context->use_color_in_console)
                 fprintf (stderr, "%s;%s%s\x1b[0m;%s;%s\n",
-                         agent->definition->name, log_colors[level],
+                         agent_name, log_colors[level],
                          log_levels[level], function, log_content);
             else
-                fprintf (stderr, "%s;%s;%s;%s\n", agent->definition->name,
+                fprintf (stderr, "%s;%s;%s;%s\n", agent_name,
                          log_levels[level], function, log_content);
         }
         else {
             if (core_context->use_color_in_console)
                 fprintf (stdout, "%s;%s%s\x1b[0m;%s;%s\n",
-                         agent->definition->name, log_colors[level],
+                         agent_name, log_colors[level],
                          log_levels[level], function, log_content);
             else
-                fprintf (stdout, "%s;%s;%s;%s\n", agent->definition->name,
+                fprintf (stdout, "%s;%s;%s;%s\n", agent_name,
                          log_levels[level], function, log_content);
         }
     }

--- a/src/igsagent.c
+++ b/src/igsagent.c
@@ -236,5 +236,5 @@ void igsagent_log (igs_log_level_t level,
     char content[IGS_MAX_STRING_MSG_LENGTH] = "";
     vsnprintf (content, IGS_MAX_STRING_MSG_LENGTH - 1, format, list);
     va_end (list);
-    admin_log (agent, level, function, "%s", content);
+    admin_log (agent->definition->name, level, function, "%s", content);
 }

--- a/test/src/tester.c
+++ b/test/src/tester.c
@@ -66,6 +66,7 @@ void agentEvent(igs_agent_event_t event, const char *uuid, const char *name, voi
 
 igsagent_t *firstAgent = NULL;
 igsagent_t *secondAgent = NULL;
+igsagent_t *thirdAgent = NULL;
 bool first_secondAgentEntered = false;
 bool first_secondAgentKnowsUs = false;
 bool first_secondAgentExited = false;
@@ -345,8 +346,8 @@ void testerIOPCallback(igs_iop_type_t iopType, const char* name, igs_iop_value_t
 // MAIN & OPTIONS & COMMAND INTERPRETER
 //
 int main(int argc, const char * argv[]) {
-    myData = malloc(32);
-    myOtherData = malloc(64);
+    myData = calloc(1,32);
+    myOtherData = calloc(1,64);
 
     //manage options
     int opt = 0;
@@ -1799,7 +1800,23 @@ int main(int argc, const char * argv[]) {
         igsagent_destroy(&secondAgent);
         igs_stop();
         igsagent_destroy(&firstAgent);
+
+        // Test start igs without default agent
         igs_clear_context();
+        thirdAgent = igsagent_new("ThirdAgent", false);
+        igsagent_definition_set_description(thirdAgent, "Third virtual agent");
+        igsagent_definition_set_version(thirdAgent, "1.0");
+        igsagent_input_create(thirdAgent, "second_impulsion", IGS_IMPULSION_T, NULL, 0);
+        igs_start_with_device(networkDevice, port);
+        igs_stop();
+        igsagent_destroy(&thirdAgent);
+
+        // Test start igs without agent
+        igs_clear_context();
+        igs_start_with_device(networkDevice, port);
+        igs_stop();
+        igs_clear_context();
+
         exit(EXIT_SUCCESS);
     }else{
         //we run normally


### PR DESCRIPTION
Try to fix issue: https://github.com/zeromq/ingescape/issues/25

I added test on igsTester to highlight the issue.

The fix consist on adding platform_name in igs context, initialize to zyre_node name.
Its Value is agent name in case of using default agent from igs, or zyre_node uuid in case of multi igs agent.

If you agree with the issue, maybe you want to discuss about the function admin_log from ingescape_private.h, because now I change the interface. I can keep the old function, who will call the new one.