### PR TITLE
Problem: JSON generation fails when output values are strings with other than UTF-8 encoding

### DIFF
--- a/src/igs_json.c
+++ b/src/igs_json.c
@@ -287,10 +287,14 @@ igs_json_add_string (igs_json_t *json, const char *value)
     if (value == NULL)
         value = "";
     igsyajl_gen_t *g = (struct igsyajl_gen *) json;
-    igsyajl_gen_status status =
-      igsyajl_gen_string (g, (unsigned const char *) value, strlen (value));
-    if (status != igsyajl_gen_status_ok)
+    igsyajl_gen_status status = igsyajl_gen_string (g, (unsigned const char *) value, strlen (value));
+    if (status != igsyajl_gen_status_ok){
         s_igs_json_error (status, __func__, &value);
+        igs_error("Trying to add a empty string instead");
+        igsyajl_gen_status status = igsyajl_gen_string (g, "", 0);
+        if (status != igsyajl_gen_status_ok)
+            s_igs_json_error (status, __func__, &value);
+    }
 }
 
 void

--- a/src/igs_json.c
+++ b/src/igs_json.c
@@ -290,8 +290,8 @@ igs_json_add_string (igs_json_t *json, const char *value)
     igsyajl_gen_status status = igsyajl_gen_string (g, (unsigned const char *) value, strlen (value));
     if (status != igsyajl_gen_status_ok){
         s_igs_json_error (status, __func__, &value);
-        igs_error("Trying to add a empty string instead");
-        igsyajl_gen_status status = igsyajl_gen_string (g, "", 0);
+        igs_error("Trying to add 'null' instead");
+        igsyajl_gen_status status = igsyajl_gen_null (g);
         if (status != igsyajl_gen_status_ok)
             s_igs_json_error (status, __func__, &value);
     }


### PR DESCRIPTION
**Situation encountered on Linux (Debian 11) only.** Works fine on macOS. Not tested on Windows.  
Given an agent with an output of type string.  
When another agent enters, the first agent will send its definition.  
However, if the last output value (that will be included in the definition) contains non-UTF-8 characters, the JSON generation fails with this error message.  
```
MyAgent;ERROR;s_igs_json_error;igs_json_add_string - an invalid string was passed
```

This result in a invalid generated JSON like this :
```json
{
    "name": "MyOutput",
    "type": "STRING",
    "value"
}
```

When the other agent receives this ill-formed JSON definition, it logs it and discards the agent.
```
MyAgent;ERROR;s_manage_zyre_incoming;received definition from remote agent MyOtherAgent(2BAAF9B5BF72934A93F70764104CE071) is empty or invalid : agent will not be registered
MyAgent;ERROR;s_manage_zyre_incoming;no known remote agent with uuid '2BAAF9B5BF72934A93F70764104CE071': rejecting
```

This behavior implies that any agent launched on the same platform as the one with the problematic output will not be able to interact with it.


**Solution:**  
The quick and easy solution is to always generate a valid JSON, even if a bad value is given, by replacing it with a JSON 'null' value instead.  
This way, the definition sent to other agents will be a valid JSON and other agents will be able to run properly.

This PR fixes the problem encountered with strings. Should we fix it with other types too ?