### PR TITLE
Problem: On Windows, when the current locale uses another decimal separator than point (for example, french locale uses a comma), ingescape generates invalid JSON & fails to convert JSON string to double.

### DIFF
--- a/bindings/javascript-node/package.json
+++ b/bindings/javascript-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ingescape",
-  "version": "3.2.0",
+  "version": "3.3.1",
   "main": "index.js",
   "types": "/types/index.d.ts",
   "scripts": {
@@ -15,7 +15,6 @@
   "author": "Ingenuity I/O",
   "license": "MPLV2",
   "dependencies": {
-    "ingescape": "^3.0.0",
     "node-gyp": "^9.0.0",
     "node-gyp-build": "^4.3.0",
     "prebuildify": "^5.0.1"

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -18,7 +18,7 @@ __copyright__ = "Copyright (c) the Contributors as noted in the AUTHORS file.\
                   License, v. 2.0. If a copy of the MPL was not distributed with this\
                   file, You can obtain one at http://mozilla.org/MPL/2.0/."
 __license__ = "All rights reserved."
-__version__ = "3.2.0"
+__version__ = "3.3.1"
 
 import sys
 from setuptools import setup

--- a/include/ingescape.h
+++ b/include/ingescape.h
@@ -32,7 +32,7 @@
 //  INGESCAPE version macros for compile-time API detection
 #define INGESCAPE_VERSION_MAJOR 3
 #define INGESCAPE_VERSION_MINOR 3
-#define INGESCAPE_VERSION_PATCH 0
+#define INGESCAPE_VERSION_PATCH 1
 
 #define INGESCAPE_MAKE_VERSION(major, minor, patch) \
 ((major) * 10000 + (minor) * 100 + (patch))

--- a/src/yajl.c
+++ b/src/yajl.c
@@ -14,15 +14,53 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "yajl_common.h"
 #include "yajl_parse.h"
 #include "yajl_lex.h"
 #include "yajl_parser.h"
 #include "yajl_alloc.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
 #include <assert.h>
+
+#if defined(_WIN32) || defined(WIN32)
+#include <locale.h>
+static _locale_t s_invariant_locale = NULL;
+
+static _locale_t 
+s_igsyajl_get_C_locale() 
+{
+    if (s_invariant_locale == NULL)
+        s_invariant_locale = _create_locale(LC_ALL, "C");
+    return s_invariant_locale;
+}
+#endif
+
+int 
+igsyajl_snprintf(char *s, size_t n, const char *format, ...)
+{
+    va_list list;
+    va_start(list, format);
+#if defined(_WIN32) || defined(WIN32)
+    return _vsnprintf_l(s, n, format, s_igsyajl_get_C_locale(), list);
+#else
+    return vsnprintf(s, n, format, list);
+#endif
+    va_end (list);
+}
+
+double 
+igsyajl_strtod (const char* str, char** endptr)
+{
+#if defined(_WIN32) || defined(WIN32)
+    return _strtod_l(str, endptr, s_igsyajl_get_C_locale());
+#else
+    return strtod(str, endptr);
+#endif
+}
 
 const char *
 igsyajl_status_to_string(igsyajl_status stat)

--- a/src/yajl_common.h
+++ b/src/yajl_common.h
@@ -68,6 +68,11 @@ typedef struct
     void * ctx;
 } igsyajl_alloc_funcs;
 
+/** Locale insensitive variants of snprintf and strtod to always use a point
+ *  as decimal separator. */
+int igsyajl_snprintf(char *s, size_t n, const char *format, ...);
+double igsyajl_strtod (const char* str, char** endptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/yajl_gen.c
+++ b/src/yajl_gen.c
@@ -230,7 +230,7 @@ igsyajl_gen_double(igsyajl_gen_t *g, double number)
     ENSURE_VALID_STATE; ENSURE_NOT_KEY;
     if (isnan(number) || isinf(number)) return igsyajl_gen_invalid_number;
     INSERT_SEP; INSERT_WHITESPACE;
-    snprintf(i, 32, "%.20g", number);
+    igsyajl_snprintf(i, 32, "%.20g", number);
     if (strspn(i, "0123456789-") == strlen(i)) {
         strncat(i, ".0", 31);
     }

--- a/src/yajl_parser.c
+++ b/src/yajl_parser.c
@@ -311,7 +311,7 @@ igsyajl_do_parse(igsyajl_handle hand, const unsigned char * jsonText,
                             igsyajl_buf_append(hand->decodeBuf, buf, bufLen);
                             buf = igsyajl_buf_data(hand->decodeBuf);
                             errno = 0;
-                            d = strtod((char *) buf, NULL);
+                            d = igsyajl_strtod((char *) buf, NULL);
                             if ((d >= HUGE_VAL || d <= -HUGE_VAL) &&
                                 errno == ERANGE)
                             {

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -317,7 +317,7 @@ static int handle_number (void *ctx, const char *string, size_t string_length)
 
     endptr = NULL;
     errno = 0;
-    v->u.number.d = strtod(v->u.number.r, &endptr);
+    v->u.number.d = igsyajl_strtod(v->u.number.r, &endptr);
     if ((errno == 0) && (endptr) && (*endptr == 0))
         v->u.number.flags |= IGSYAJL_NUMBER_DOUBLE_VALID;
 


### PR DESCRIPTION
Solution:
On Windows, use C locale for json double generation and parsing.

Opened question: 
Ingescape uses atof to convert IOP values from string to double and snprintf to convert IOP values from double to string and is locale sensitive. Should a double IOP always be converted with a point as decimal separator ? If yes, this solution must be applied more globally. 
