### PR TITLE
Update python binding

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -901,10 +901,12 @@ test-python:
     - cp -r ../../dependencies/sodium/src/libsodium/include/* ./dependencies/include
     - cp -r ../../dependencies/zyre/include/* ./dependencies/include
     - export FROM_SOURCES="true"
+    - ./prepare_setup.sh
     - ./tests/run_tests.sh
   artifacts:
     paths:
       - bindings/python/dependencies/*
+      - bindings/python/setup.py
   dependencies:
     - lib-build-linux-x64
   needs:
@@ -978,6 +980,7 @@ package-python-wheels-macos:
     paths:
       - bindings/python/dist/*
       - bindings/python/dependencies/*
+      - bindings/python/setup.py
   rules:
     - !reference [.base_repo_main_branch, rules]
 
@@ -998,6 +1001,7 @@ package-python-wheels-manylinux_2_24_x86_64:
     - python3.8 setup.py bdist_wheel
     - python3.9 setup.py bdist_wheel
     - python3.10 setup.py bdist_wheel
+    - python3.11 setup.py bdist_wheel
     - |
         for whl in dist/*.whl; do
           auditwheel repair "$whl" --plat "manylinux_2_24_x86_64" -w ./wheelhouse/
@@ -1031,6 +1035,8 @@ package-python-wheels-manylinux2014_x86_64:
     - python3.7 setup.py bdist_wheel
     - python3.8 setup.py bdist_wheel
     - python3.9 setup.py bdist_wheel
+    - python3.10 setup.py bdist_wheel
+    - python3.11 setup.py bdist_wheel
     - |
         for whl in dist/*.whl; do
           auditwheel repair "$whl" --plat "manylinux2014_x86_64" -w ./wheelhouse/
@@ -1062,6 +1068,8 @@ package-python-wheels-manylinux2010_x86_64:
     - cp ../../build/dependencies/sodium//libsodium.a ./dependencies/linux
     - export FROM_SOURCES="true"
     - python3.7 setup.py bdist_wheel
+    - python3.8 setup.py bdist_wheel
+    - python3.9 setup.py bdist_wheel
     - python3.8 setup.py bdist_wheel
     - |
         for whl in dist/*.whl; do

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -4,3 +4,4 @@ ingescape.egg-info/
 venv/
 
 .*.swp
+setup.py

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -10,9 +10,9 @@ The Ingescape Python binding relies on the following libraries:
 
 ## Installing
 
-Ingescape python is designed to be installed trough pip :
+Ingescape python binding is designed to be installed through pip :
 
-	python3 -m pip install ingescape
+    python3 -m pip install ingescape
 
 
 ## Using Ingescape with Python
@@ -24,5 +24,6 @@ Two examples are provided in the 'examples' directory.
 
 Run the following commands from the Ingescape Python directory :
 
-	python3 -m pip install setuptools wheel
-	python3 -m pip install .
+    python3 -m pip install setuptools wheel
+    ./prepare_setup.sh (or prepare_setup.ps1 for Windows Powershell)
+    python3 -m pip install .

--- a/bindings/python/includes/compat.h
+++ b/bindings/python/includes/compat.h
@@ -1,0 +1,17 @@
+#ifndef _INGESCAPE_PY_COMPAT_H
+#define _INGESCAPE_PY_COMPAT_H
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <frameobject.h>
+
+// PyFrame_GetCode is available since python 3.9
+// And the PyFrameObject* struct is opaque since python 3.11
+// We make PyFrame_GetCode available for python 3.8 and older
+// https://docs.python.org/3/whatsnew/3.11.html#pyframeobject-3-11-hiding
+#if PY_VERSION_HEX < 0x030900B1
+PyCodeObject* PyFrame_GetCode(PyFrameObject *frame);
+#endif
+
+
+#endif // _INGESCAPE_PY_COMPAT_H

--- a/bindings/python/includes/ingescape_agent_python.h
+++ b/bindings/python/includes/ingescape_agent_python.h
@@ -17,6 +17,8 @@
 #include <Python.h>
 #include <frameobject.h>
 
+#include "compat.h"
+
 #ifdef FROM_SOURCES
 #include "igsagent.h"
 #include "czmq.h"

--- a/bindings/python/includes/ingescape_python.h
+++ b/bindings/python/includes/ingescape_python.h
@@ -17,6 +17,8 @@
 #include <Python.h>
 #include <frameobject.h>
 
+#include "compat.h"
+
 #ifdef FROM_SOURCES
 #include "ingescape.h"
 #include "czmq.h"
@@ -80,8 +82,8 @@ extern freezeCallback_t *freezeList;
 PyObject * observe_freeze_wrapper(PyObject *self, PyObject *args);
 
 typedef struct agentEventCallback{
-    PyObject *call;
-    PyObject *argList;
+    PyObject *callback;
+    PyObject *my_data;
     struct agentEventCallback *next;
     struct agentEventCallback *prev;
 }agentEventCallback_t;
@@ -211,7 +213,7 @@ PyObject * mapping_set_outputs_request_wrapper(PyObject * self, PyObject * args)
 PyObject * mapping_outputs_request_wrapper(PyObject * self, PyObject * args);
 
 
-PyObject *sendCall_wrapper(PyObject * self, PyObject * args);
+PyObject *service_call_wrapper(PyObject * self, PyObject * args);
 
 typedef struct callCallback {
     char *callName;

--- a/bindings/python/includes/util.h
+++ b/bindings/python/includes/util.h
@@ -1,0 +1,13 @@
+#ifndef _UTIL_H
+#define _UTIL_H
+
+#include <Python.h>
+
+/**
+ * Helper method used when python callbacks need to be called from C
+ * This method checks the success of the python callback after calling it
+ * and prints any exception that might have been raised
+ */
+void call_callback(PyObject* callback, PyObject* args);
+
+#endif // #_UTIL_H

--- a/bindings/python/prepare_setup.ps1
+++ b/bindings/python/prepare_setup.ps1
@@ -1,0 +1,7 @@
+
+$IHM_VERSION_MAJOR = Select-String "#define INGESCAPE_VERSION_MAJOR" ..\..\include\ingescape.h | ForEach-Object { ([string]$_).Split(" ")[2] }
+$IHM_VERSION_MINOR = Select-String "#define INGESCAPE_VERSION_MINOR" ..\..\include\ingescape.h | ForEach-Object { ([string]$_).Split(" ")[2] }
+$IHM_VERSION_PATCH = Select-String "#define INGESCAPE_VERSION_PATCH" ..\..\include\ingescape.h | ForEach-Object { ([string]$_).Split(" ")[2] }
+$NEW_CIRCLE_VER = "$IHM_VERSION_MAJOR.$IHM_VERSION_MINOR.$IHM_VERSION_PATCH"
+
+(Get-Content ./setup.py.in) -Replace '@IGS_VERSION@', "$NEW_CIRCLE_VER" | Set-Content ./setup.py

--- a/bindings/python/prepare_setup.sh
+++ b/bindings/python/prepare_setup.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(cd `dirname $0`; pwd)
+SCRIPT_NAME=$(basename $0)
+
+function print_usage {
+    echo "Usage: $SCRIPT_NAME [-h]"
+    echo "  -h               : Show this help message and exit."
+}
+
+while getopts ":h" opt
+do
+    case "${opt}" in
+        h) # Help option
+            print_usage
+            exit 0
+            ;;
+        :) # Option with missing argument
+            echo "ERROR: -${OPTARG} requires an argument"
+            print_usage
+            exit 100
+            ;;
+        *) # Unknown option
+            echo "ERROR: unknown parameter -${OPTARG}"
+            print_usage
+            exit 110
+            ;;
+    esac
+done
+
+(
+  cd $SCRIPT_DIR
+
+  IGS_MAJOR=$(grep "#define INGESCAPE_VERSION_MAJOR" ../../include/ingescape.h | cut -d' ' -f3)
+  IGS_MINOR=$(grep "#define INGESCAPE_VERSION_MINOR" ../../include/ingescape.h | cut -d' ' -f3)
+  IGS_PATCH=$(grep "#define INGESCAPE_VERSION_PATCH" ../../include/ingescape.h | cut -d' ' -f3)
+
+  sed "s/@IGS_VERSION@/\"$IGS_MAJOR.$IGS_MINOR.$IGS_PATCH\"/" setup.py.in > setup.py
+)
+
+exit 0
+

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -48,13 +48,15 @@ from_sources = os.environ.get('FROM_SOURCES', default=None)
 if from_sources:
   __version__ = version_str("./dependencies/include/ingescape.h")
 else:
-  __version__ = version_str(os.path.dirname(os.path.realpath(__file__)) + "/../../include/ingescape.h")
+  __version__ = @IGS_VERSION@
 
 ingescape_src = ["./src/ingescape_python.c", "./src/admin.c",
                   "./src/channels.c",  "./src/core.c",
                   "./src/monitor.c", "./src/network.c",
                   "./src/performance.c",
-                  "./src/replay.c"]
+                  "./src/replay.c",
+                  "./src/compat.c",
+                  "./src/util.c"]
 ingescape_agent_src =["./src/agent.c"]
 ingescape_include = ["./includes"]
 

--- a/bindings/python/src/admin.c
+++ b/bindings/python/src/admin.c
@@ -146,7 +146,8 @@ PyObject * trace_wrapper(PyObject * self, PyObject * args)
     PyFrameObject* frame = PyEval_GetFrame();
     Py_INCREF(frame);
     // Get function name to print it in log
-    PyObject *function = frame->f_code->co_name;
+    PyCodeObject* f_code = PyFrame_GetCode(frame);
+    PyObject *function = f_code->co_name;
     Py_INCREF(function);
     Py_DECREF(frame);
 
@@ -174,7 +175,8 @@ PyObject * debug_wrapper(PyObject * self, PyObject * args)
     PyFrameObject* frame = PyEval_GetFrame();
     Py_INCREF(frame);
     // Get function name to print it in log
-    PyObject *function = frame->f_code->co_name;
+    PyCodeObject* f_code = PyFrame_GetCode(frame);
+    PyObject *function = f_code->co_name;
     Py_INCREF(function);
     Py_DECREF(frame);
     PyObject* funcTuple = Py_BuildValue("(O)", function);
@@ -201,7 +203,8 @@ PyObject * info_wrapper(PyObject * self, PyObject * args)
         return NULL;
     PyFrameObject* frame = PyEval_GetFrame();
     Py_INCREF(frame);
-    PyObject *function = frame->f_code->co_name;
+    PyCodeObject* f_code = PyFrame_GetCode(frame);
+    PyObject *function = f_code->co_name;
     Py_INCREF(function);
     Py_DECREF(frame);
     PyObject* funcTuple = Py_BuildValue("(O)", function);
@@ -228,7 +231,8 @@ PyObject * warn_wrapper(PyObject * self, PyObject * args)
         return NULL;
     PyFrameObject* frame = PyEval_GetFrame();
     Py_INCREF(frame);
-    PyObject *function = frame->f_code->co_name;
+    PyCodeObject* f_code = PyFrame_GetCode(frame);
+    PyObject *function = f_code->co_name;
     Py_INCREF(function);
     Py_DECREF(frame);
     PyObject* funcTuple = Py_BuildValue("(O)", function);
@@ -254,7 +258,8 @@ PyObject * error_wrapper(PyObject * self, PyObject * args)
         return NULL;
     PyFrameObject* frame = PyEval_GetFrame();
     Py_INCREF(frame);
-    PyObject *function = frame->f_code->co_name;
+    PyCodeObject* f_code = PyFrame_GetCode(frame);
+    PyObject *function = f_code->co_name;
     Py_INCREF(function);
     Py_DECREF(frame);
     PyObject* funcTuple = Py_BuildValue("(O)", function);
@@ -280,7 +285,8 @@ PyObject * fatal_wrapper(PyObject * self, PyObject * args)
         return NULL;
     PyFrameObject* frame = PyEval_GetFrame();
     Py_INCREF(frame);
-    PyObject *function = frame->f_code->co_name;
+    PyCodeObject* f_code = PyFrame_GetCode(frame);
+    PyObject *function = f_code->co_name;
     Py_INCREF(function);
     Py_DECREF(frame);
 

--- a/bindings/python/src/compat.c
+++ b/bindings/python/src/compat.c
@@ -1,0 +1,13 @@
+#include "compat.h"
+
+// PyFrame_GetCode is available since python 3.9
+// And the PyFrameObject* struct is opaque since python 3.11
+// We make PyFrame_GetCode available for python 3.8 and older
+// https://docs.python.org/3/whatsnew/3.11.html#pyframeobject-3-11-hiding
+#if PY_VERSION_HEX < 0x030900B1
+PyCodeObject* PyFrame_GetCode(PyFrameObject *frame)
+{
+    Py_INCREF(frame->f_code);
+    return frame->f_code;
+}
+#endif

--- a/bindings/python/src/ingescape_python.c
+++ b/bindings/python/src/ingescape_python.c
@@ -213,7 +213,7 @@ static PyMethodDef Ingescape_methods[] =
     {"net_addresses_list", net_addresses_list_wrapper, METH_NOARGS, "net_addresses_list()\n--\n\n "},
 
     // Services
-    {"service_call", sendCall_wrapper, METH_VARARGS, "service_call(agent_name_or_uuid, service_name, tuple_arguments, token, )\n--\n\n "},
+    {"service_call", service_call_wrapper, METH_VARARGS, "service_call(agent_name_or_uuid, service_name, tuple_arguments, token, )\n--\n\n "},
     {"service_init", service_init_wrapper, METH_VARARGS, "service_init(service_name, callback, my_data, )\n--\n\n "},
     {"service_remove", service_remove_wrapper, METH_VARARGS, "service_remove(service_name, )\n--\n\n "},
     {"service_arg_add", service_arg_add_wrapper, METH_VARARGS, "service_arg_add(service_name, argument_name, argument_type, )\n--\n\n "},
@@ -437,7 +437,7 @@ static PyObject *Agent_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return (PyObject *)self;
 }
 
-static int *Agent_init(AgentObject *self, PyObject *args, PyObject *kwds)
+static int Agent_init(AgentObject *self, PyObject *args, PyObject *kwds)
 {
     static char *kwlist[] = {"name", "activate_immediately", NULL};
     char *name = NULL;

--- a/bindings/python/src/monitor.c
+++ b/bindings/python/src/monitor.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) the Contributors as noted in the AUTHORS file.
  * This file is part of Ingescape, see https://github.com/zeromq/ingescape.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -16,6 +16,7 @@
 
 #include "ingescape_python.h"
 #include "uthash/utlist.h"
+#include "util.h"
 
 monitor_cb_t *observe_monitor_cbList = NULL;
 void observe_monitor_callback(igs_monitor_event_t event, const char *device, const char *ip_address, void *my_data)
@@ -26,14 +27,14 @@ void observe_monitor_callback(igs_monitor_event_t event, const char *device, con
     d_gstate = PyGILState_Ensure();
     PyObject *tupleArgs = PyTuple_New(4);
     PyTuple_SetItem(tupleArgs, 0, Py_BuildValue("i", event));
-    PyTuple_SetItem(tupleArgs, 1, Py_BuildValue("s", device));
-    PyTuple_SetItem(tupleArgs, 2, Py_BuildValue("s", ip_address));
+    PyTuple_SetItem(tupleArgs, 1, PyUnicode_DecodeLocale(device, NULL));
+    PyTuple_SetItem(tupleArgs, 2, PyUnicode_DecodeLocale(ip_address, NULL));
     monitor_cb_t *actuel = NULL;
-    DL_FOREACH(observe_monitor_cbList, actuel) 
+    DL_FOREACH(observe_monitor_cbList, actuel)
     {
         Py_INCREF(actuel->my_data);
         PyTuple_SetItem(tupleArgs, 3, actuel->my_data);
-        PyObject_Call(actuel->callback, tupleArgs, NULL);
+        call_callback(actuel->callback, tupleArgs);
         Py_XDECREF(tupleArgs);
     }
     //release the GIL
@@ -85,7 +86,7 @@ PyObject * igs_monitor_start_with_network_wrapper(PyObject *self, PyObject *args
 PyObject * igs_monitor_stop_wrapper(PyObject *self, PyObject *args, PyObject *kwds)
 {
     igs_monitor_stop();
-    return PyLong_FromLong(IGS_SUCCESS);   
+    return PyLong_FromLong(IGS_SUCCESS);
 }
 
 PyObject * igs_monitor_is_running_wrapper(PyObject *self, PyObject *args, PyObject *kwds)
@@ -105,4 +106,3 @@ PyObject * igs_monitor_set_start_stop_wrapper(PyObject *self, PyObject *args, Py
     igs_monitor_set_start_stop(flag);
     return PyLong_FromLong(IGS_SUCCESS);
 }
-

--- a/bindings/python/src/util.c
+++ b/bindings/python/src/util.c
@@ -1,0 +1,15 @@
+#include "util.h"
+
+void call_callback(PyObject* callback, PyObject* args){
+    assert(callback);
+    assert(args);
+
+    PyObject* result = PyObject_CallObject(callback, args);
+    if (result != NULL)
+        Py_DECREF(result);
+    else{
+        if (PyErr_Occurred()){
+            PyErr_Print();
+        }
+    }
+}


### PR DESCRIPTION
Several fixes and improvements :  
- Compatibility with python 3.11
- Exception handling in the callbacks (prints out the exception then releases the interpreter lock)
- Fix agent events callback (context data weren't passed to the callbacks properly)
- Minor renaming to match the ingescape API
- Some fixes in reference counts (C side)
- CI pipelines updated to build more pre-built packages