### PR TITLE
Node JS binding update

### DIFF
--- a/bindings/javascript-node/package.json
+++ b/bindings/javascript-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ingescape",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "main": "index.js",
   "types": "/types/index.d.ts",
   "scripts": {

--- a/bindings/javascript-node/src/agent.c
+++ b/bindings/javascript-node/src/agent.c
@@ -1959,6 +1959,16 @@ napi_value node_igsagent_clear_mappings_with_agent(napi_env env, napi_callback_i
     return NULL;
 }
 
+napi_value node_igsagent_clear_mappings_for_input(napi_env env, napi_callback_info info) {
+    napi_value argv[1], this;
+    get_function_arguments(env, info, 1, argv);
+    this = get_function_this_argument(env, info);
+    char *input_name = convert_napi_to_string(env, argv[0]);
+    igsagent_clear_mappings_for_input(unwrap_native_agent(env, this), input_name);
+    free(input_name);
+    return NULL;
+}
+
 napi_value node_igsagent_mapping_add(napi_env env, napi_callback_info info) {
     napi_value argv[3], this;
     get_function_arguments(env, info, 3, argv);
@@ -2753,6 +2763,7 @@ napi_value init_agent(napi_env env, napi_value exports) {
         { "mappingCount", NULL, node_igsagent_mapping_count, NULL, NULL, NULL, napi_writable | napi_configurable, NULL},
         { "clearMappings", NULL, node_igsagent_clear_mappings, NULL, NULL, NULL, napi_writable | napi_configurable, NULL},
         { "clearMappingsWithAgent", NULL, node_igsagent_clear_mappings_with_agent, NULL, NULL, NULL, napi_writable | napi_configurable, NULL},
+        { "clearMappingsForInput", NULL, node_igsagent_clear_mappings_for_input, NULL, NULL, NULL, napi_writable | napi_configurable, NULL},
         { "mappingAdd", NULL, node_igsagent_mapping_add, NULL, NULL, NULL, napi_writable | napi_configurable, NULL},
         { "mappingRemoveWithId", NULL, node_igsagent_mapping_remove_with_id, NULL, NULL, NULL, napi_writable | napi_configurable, NULL},
         { "mappingRemoveWithName", NULL, node_igsagent_mapping_remove_with_name, NULL, NULL, NULL, napi_writable | napi_configurable, NULL},

--- a/bindings/javascript-node/src/mapping.c
+++ b/bindings/javascript-node/src/mapping.c
@@ -48,6 +48,15 @@ napi_value node_igs_clear_mappings_with_agent(napi_env env, napi_callback_info i
     return NULL;
 }
 
+napi_value node_igs_clear_mappings_for_input(napi_env env, napi_callback_info info) {
+    napi_value argv[1];
+    get_function_arguments(env, info, 1, argv);
+    char *input_name = convert_napi_to_string(env, argv[0]);
+    igs_clear_mappings_for_input(input_name);
+    free(input_name);
+    return NULL;
+}
+
 napi_value node_igs_mapping_json(napi_env env, napi_callback_info info) {
     char *json = igs_mapping_json();
     napi_value json_js;
@@ -157,7 +166,8 @@ napi_value init_mapping(napi_env env, napi_value exports) {
     exports = enable_callback_into_js(env, node_igs_mapping_load_str, "mappingLoadStr", exports);
     exports = enable_callback_into_js(env, node_igs_mapping_load_file, "mappingLoadFile", exports);
     exports = enable_callback_into_js(env, node_igs_clear_mappings, "clearMappings", exports);
-    exports = enable_callback_into_js(env, node_igs_clear_mappings_with_agent, "clearMappingsWithAgent", exports);    
+    exports = enable_callback_into_js(env, node_igs_clear_mappings_with_agent, "clearMappingsWithAgent", exports);
+    exports = enable_callback_into_js(env, node_igs_clear_mappings_for_input, "clearMappingsForInput", exports);
     exports = enable_callback_into_js(env, node_igs_mapping_json, "mappingJson", exports);
     exports = enable_callback_into_js(env, node_igs_mapping_count, "mappingCount", exports);
     exports = enable_callback_into_js(env, node_igs_mapping_add, "mappingAdd", exports);

--- a/bindings/javascript-node/tests/test.js
+++ b/bindings/javascript-node/tests/test.js
@@ -807,6 +807,16 @@ assert(IGS.mappingCount() === 1);
 IGS.clearMappingsWithAgent("other_agent");
 assert(IGS.mappingCount() === 0);
 assert(IGS.mappingRemoveWithName("toto", "other_agent", "tata") === igsResultEnum.IGS_FAILURE);
+assert(IGS.mappingAdd("toto", "other_agent", "tata") > 0);
+assert(IGS.mappingCount() == 1);
+IGS.clearMappingsForInput("toto");
+assert(IGS.mappingCount() == 0);
+assert(IGS.mappingAdd("toto", "other_agent", "tata") > 0);
+assert(IGS.mappingCount() == 1);
+IGS.clearMappingsForInput("tata");
+assert(IGS.mappingCount() == 1);
+IGS.clearMappingsForInput("toto");
+assert(IGS.mappingCount() == 0);
 
 assert(IGS.splitCount() === 0);
 assert(IGS.splitAdd("toto", "other_agent", "tata") != 0);

--- a/bindings/javascript-node/types/index.d.ts
+++ b/bindings/javascript-node/types/index.d.ts
@@ -276,6 +276,7 @@ export class Agent {
     mappingCount():number;
     clearMappings():undefined;
     clearMappingsWithAgent(agentName:string):undefined;
+    clearMappingsForInput(inputName:string):undefined;
     mappingAdd(fromOurInput:string, toAgent:string, withOutput:string):BigInt;
     mappingRemoveWithId(id:BigInt):number;
     mappingRemoveWithName(fromOurInput:string, toAgent:string, withOutput:string): number;
@@ -426,6 +427,7 @@ export function mappingLoadStr(jsonMapping:string):number;
 export function mappingLoadFile(path:string):number;
 export function clearMappings():undefined;
 export function clearMappingsWithAgent(name:string):undefined;
+export function clearMappingsForInput(name:string):undefined;
 export function mappingJson():string;
 export function mappingCount():number;
 export function mappingAdd(fromOurInput:string, toAgent:string, withOutput:string):BigInt;


### PR DESCRIPTION
Add **clearMappingsForInput** method in Node JS binding, upgrade version to 3.4.0. 
