### PR TITLE
Problem : two "IGS_AGENT_KNOWS_US" received when an igsagent is activated after its creation

### DIFF
--- a/src/igsagent.c
+++ b/src/igsagent.c
@@ -155,8 +155,6 @@ igs_result_t igsagent_activate (igsagent_t *agent)
         DL_FOREACH (agent->agent_event_callbacks, cb){
             cb->callback_ptr (agent, IGS_AGENT_ENTERED, r->uuid,
                               r->definition->name, definition_str_for_r, cb->my_data);
-            cb->callback_ptr (agent, IGS_AGENT_KNOWS_US, r->uuid,
-                              r->definition->name, NULL, cb->my_data);
         }
         if (definition_str_for_r)
             free(definition_str_for_r);


### PR DESCRIPTION
Solution : remove notification of IGS_AGENT_KNOWS_US from remote agent in igsagent_activate method because remote agent doesn't know the igsagent at this point. This event will be notified when remote agent has acknowledged the newly activated igsagent.