### PR TITLE
Problem: BAD_ACCESS in igsagent_service_call method

### DIFF
--- a/src/igs_network.c
+++ b/src/igs_network.c
@@ -936,8 +936,10 @@ int s_manage_zyre_incoming (zloop_t *loop, zsock_t *socket, void *arg)
                     split_remove_worker (context, uuid, NULL);
                     s_agent_propagate_agent_event (IGS_AGENT_EXITED, uuid,
                                                    remote->definition->name, NULL);
+                    model_read_write_lock(__FUNCTION__, __LINE__);
                     HASH_DEL (context->remote_agents, remote);
                     s_clean_and_free_remote_agent (&remote);
+                    model_read_write_unlock(__FUNCTION__, __LINE__);
                 }
                 else
                     igs_error ("%s is not a known remote agent", uuid);
@@ -2872,8 +2874,10 @@ int s_manage_zyre_incoming (zloop_t *loop, zsock_t *socket, void *arg)
                         split_remove_worker (context, remote->uuid, NULL);
                         s_agent_propagate_agent_event (IGS_AGENT_EXITED, remote->uuid,
                                                        remote->definition->name, NULL);
+                        model_read_write_lock(__FUNCTION__, __LINE__);
                         HASH_DEL (context->remote_agents, remote);
                         s_clean_and_free_remote_agent (&remote);
+                        model_read_write_unlock(__FUNCTION__, __LINE__);
                     }
                 }
                 HASH_DEL (context->zyre_peers, zyre_peer);


### PR DESCRIPTION
I had a BAD_ACCESS on a remote agent when igsagent_service_call method iterates over all remote agents and a remote agent leaves the network. igsagent_service_call is protected by the model_read_write_lock mutex at the start of the method BUT removing a remote agent in context loop is not protected (event "EXIT" and "REMOTE_AGENT_EXIT").

Solution : lock/unlock removing a remote agent in context loop.
