### PR TITLE
Problem: internal JSON parsing method igsyajl_tree_parse causes a head-buffer-overflow error

### DIFF
--- a/src/igs_json_node.c
+++ b/src/igs_json_node.c
@@ -110,8 +110,7 @@ igs_json_node_parse_from_file (const char *path)
     }
     char errbuf[1024] = "unknown error";
     zchunk_t *data = zfile_read (file, zfile_size (path), 0);
-    igs_json_node_t *node = (igs_json_node_t *) igsyajl_tree_parse (
-      (const char *) zchunk_data (data), errbuf, sizeof (errbuf));
+    igs_json_node_t *node = (igs_json_node_t *) igsyajl_tree_parse ((const char *) zchunk_data (data), zchunk_size (data), errbuf, sizeof (errbuf));
     if (node == NULL)
         igs_error ("parsing error (%s) : %s", path, errbuf);
     zchunk_destroy (&data);
@@ -125,7 +124,7 @@ igs_json_node_parse_from_str (const char *content)
     assert (content);
     char errbuf[1024] = "unknown error";
     igs_json_node_t *node =
-      (igs_json_node_t *) igsyajl_tree_parse (content, errbuf, sizeof (errbuf));
+      (igs_json_node_t *) igsyajl_tree_parse (content, strlen(content), errbuf, sizeof (errbuf));
     if (node == NULL)
         igs_error ("parsing error (%s) : %s", content, errbuf);
     return node;

--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -400,7 +400,7 @@ static int handle_null (void *ctx)
 /*
  * Public functions
  */
-igsyajl_val igsyajl_tree_parse (const char *input,
+igsyajl_val igsyajl_tree_parse (const char *input, const size_t input_size,
                           char *error_buffer, size_t error_buffer_size)
 {
     static const igsyajl_callbacks callbacks =
@@ -435,13 +435,13 @@ igsyajl_val igsyajl_tree_parse (const char *input,
 
     status = igsyajl_parse(handle,
                         (unsigned char *) input,
-                        strlen (input));
+                        input_size);
     status = igsyajl_complete_parse (handle);
     if (status != igsyajl_status_ok) {
         if (error_buffer && error_buffer_size > 0) {
                internal_err_str = (char *) igsyajl_get_error(handle, 1,
                      (const unsigned char *) input,
-                     strlen(input));
+                     input_size);
              snprintf(error_buffer, error_buffer_size, "%s", internal_err_str);
              YA_FREE(&(handle->alloc), internal_err_str);
         }

--- a/src/yajl_tree.h
+++ b/src/yajl_tree.h
@@ -118,7 +118,7 @@ struct igsyajl_val_s
  * null terminated message describing the error in more detail is stored in
  * \em error_buffer if it is not \c NULL.
  */
-IGSYAJL_API igsyajl_val igsyajl_tree_parse (const char *input,
+IGSYAJL_API igsyajl_val igsyajl_tree_parse (const char *input, const size_t input_size,
                                    char *error_buffer, size_t error_buffer_size);
 
 


### PR DESCRIPTION
`igsyajl_tree_parse` uses `strlen` to get the size of the content to parse.   
While parsing a file, we give it a `zchunk` which is not null-terminated.

Solution: Do not use `strlen` to get the size of the input to parse and give the size directly as a parameter to `igsyajl_tree_parse`.