### PR TITLE
Problem: net_devices_list() API in python make agents crash

### DIFF
--- a/bindings/python/src/network.c
+++ b/bindings/python/src/network.c
@@ -190,11 +190,11 @@ PyObject * command_line_wrapper(PyObject *self, PyObject *args, PyObject *kwds)
 
 PyObject * net_devices_list_wrapper(PyObject * self, PyObject * args)
 {
-    int nbList;
+    int nbList = 0;
     char **resultList = igs_net_devices_list(&nbList);
     PyObject *ret = PyList_New(nbList);
     for (int i = 0; i < nbList; i++)
-        PyList_SetItem(ret, i, PyUnicode_EncodeLocale(resultList[i], NULL));
+        PyList_SetItem(ret, i, Py_BuildValue("s",resultList[i]));
     igs_free_net_devices_list(resultList, nbList);
     return ret;
 }

--- a/bindings/python/src/network.c
+++ b/bindings/python/src/network.c
@@ -194,7 +194,7 @@ PyObject * net_devices_list_wrapper(PyObject * self, PyObject * args)
     char **resultList = igs_net_devices_list(&nbList);
     PyObject *ret = PyList_New(nbList);
     for (int i = 0; i < nbList; i++)
-        PyList_SetItem(ret, i, Py_BuildValue("s",resultList[i]));
+        PyList_SetItem(ret, i, PyUnicode_DecodeLocale(resultList[i], NULL));
     igs_free_net_devices_list(resultList, nbList);
     return ret;
 }

--- a/bindings/python/tests/global_api.py
+++ b/bindings/python/tests/global_api.py
@@ -30,6 +30,14 @@ def testerServiceCallback(sender_agent_name, sender_agent_uuid, service_name, ar
 def testerIOPCallback(iop_type, name, value_type, value, my_data):
     pass
 
+print ("[Global API] Net ifaces and devices", end =" ")
+print("igs.net_devices_list()")
+print(f'{igs.net_devices_list()}')
+print("igs.net_addresses_list()")
+print(f'{igs.net_addresses_list()}')
+assert len(igs.net_devices_list()) == len(igs.net_addresses_list())
+print ("OK")
+
 print ("[Global API] Testing agent name", end =" ")
 assert igs.agent_name() == "no_name"
 igs.agent_set_name("simple Demo Agent")


### PR DESCRIPTION
Because we "encode" the string from the lib instead of "decoding" it into a PyObject.

Solution: Make a proper PyObject from the devices names and let the python interpreter handles their refcount and life cycle.