### PR TITLE
DATA handling in service args

### DIFF
--- a/bindings/python/src/agent.c
+++ b/bindings/python/src/agent.c
@@ -2073,30 +2073,39 @@ PyObject *Agent_service_call(AgentObject *self, PyObject *args, PyObject *kwds)
                     igs_service_args_add_string(&argumentList, PyUnicode_AsUTF8AndSize(newArgument, &size));
                 }
                 else
-                    igs_service_args_add_data(&argumentList, PyBytes_FromObject(newArgument), PyBytes_Size(newArgument));
+                {
+                    if (PyByteArray_Check(newArgument))
+                        igs_service_args_add_data(&argumentList, PyByteArray_AsString(newArgument), PyByteArray_Size(newArgument));
+                    else if (PyBytes_Check(newArgument))
+                        igs_service_args_add_data(&argumentList, PyBytes_AsString(newArgument), PyBytes_Size(newArgument));
+                }
             }
         }
         result = igsagent_service_call(self->agent, agentNameOrUUID, serviceName, &argumentList, token);
         igs_service_args_destroy(&argumentList);
     }else if (format == 1){
         if(PyLong_CheckExact(argTuple))
-                igs_service_args_add_int(&argumentList, (int)PyLong_AsLong(argTuple));
-            else if(PyFloat_CheckExact(argTuple))
-                igs_service_args_add_double(&argumentList, PyFloat_AsDouble(argTuple));
-            else if(PyBool_Check(argTuple))
-            {
-                if(argTuple == Py_True)
-                    igs_service_args_add_bool(&argumentList, true);
-                else
-                    igs_service_args_add_bool(&argumentList, false);
-            }
-            else if(PyUnicode_Check(argTuple))
-            {
-                Py_ssize_t size;
-                igs_service_args_add_string(&argumentList, PyUnicode_AsUTF8AndSize(argTuple, &size));
-            }
+            igs_service_args_add_int(&argumentList, (int)PyLong_AsLong(argTuple));
+        else if(PyFloat_CheckExact(argTuple))
+            igs_service_args_add_double(&argumentList, PyFloat_AsDouble(argTuple));
+        else if(PyBool_Check(argTuple))
+        {
+            if(argTuple == Py_True)
+                igs_service_args_add_bool(&argumentList, true);
             else
-                igs_service_args_add_data(&argumentList, PyBytes_FromObject(argTuple), PyBytes_Size(argTuple));
+                igs_service_args_add_bool(&argumentList, false);
+        }
+        else if(PyUnicode_Check(argTuple))
+        {
+            Py_ssize_t size;
+            igs_service_args_add_string(&argumentList, PyUnicode_AsUTF8AndSize(argTuple, &size));
+        }
+        else{
+            if (PyByteArray_Check(argTuple))
+                igs_service_args_add_data(&argumentList, PyByteArray_AsString(argTuple), PyByteArray_Size(argTuple));
+            else if (PyBytes_Check(argTuple))
+                igs_service_args_add_data(&argumentList, PyBytes_AsString(argTuple), PyBytes_Size(argTuple));
+        }
         result = igsagent_service_call(self->agent, agentNameOrUUID, serviceName, &argumentList, token);
         igs_service_args_destroy(&argumentList);
     }else

--- a/bindings/python/src/core.c
+++ b/bindings/python/src/core.c
@@ -1452,8 +1452,12 @@ PyObject * service_call_wrapper(PyObject * self, PyObject * args)
                 }
                 else if(PyUnicode_Check(newArgument))
                     igs_service_args_add_string(&argumentList, PyUnicode_AsUTF8(newArgument));
-                else
-                    igs_service_args_add_data(&argumentList, PyBytes_FromObject(newArgument), PyBytes_Size(newArgument));
+                else{
+                    if (PyByteArray_Check(newArgument))
+                        igs_service_args_add_data(&argumentList, PyByteArray_AsString(newArgument), PyByteArray_Size(newArgument));
+                    else if (PyBytes_Check(newArgument))
+                        igs_service_args_add_data(&argumentList, PyBytes_AsString(newArgument), PyBytes_Size(newArgument));
+                }
             }
         }
         result = igs_service_call(agentNameOrUUID, callName, &argumentList, token);
@@ -1470,9 +1474,12 @@ PyObject * service_call_wrapper(PyObject * self, PyObject * args)
                     igs_service_args_add_bool(&argumentList, false);
             }else if(PyUnicode_Check(argTuple))
                 igs_service_args_add_string(&argumentList, PyUnicode_AsUTF8(argTuple));
-            else
-                igs_service_args_add_data(&argumentList, PyBytes_FromObject(argTuple), PyBytes_Size(argTuple));
-
+            else{
+                if (PyByteArray_Check(argTuple))
+                    igs_service_args_add_data(&argumentList, PyByteArray_AsString(argTuple), PyByteArray_Size(argTuple));
+                else if (PyBytes_Check(argTuple))
+                    igs_service_args_add_data(&argumentList, PyBytes_AsString(argTuple), PyBytes_Size(argTuple));
+            }
             result = igs_service_call(agentNameOrUUID, callName, &argumentList, token);
         }else
             result = igs_service_call(agentNameOrUUID, callName, NULL, token);


### PR DESCRIPTION
Passing `bytes` to a service DATA arg seems to send garbage, at least in front of the real DATA.
Passing `bytearray` straight throws an OOM error, event when passing just a few bytes.

It appears that the python wrapper uses the wrong python C-API to pass DATA to `igs_service_args_add_data` resulting in conversion error or wrong memory block passed to ingescape.

Solution: Check if passed python object is of types `bytes` or `bytearray` and use the proper APIs to convert python data object to C `char*`

NOTE: There is still problems with sending DATA as output.
An other PR should follow with corrections about that (related issue #67).