### PR TITLE
Problem: [python binding] using timers causes segfault

### DIFF
--- a/bindings/python/src/network.c
+++ b/bindings/python/src/network.c
@@ -389,7 +389,7 @@ PyObject * igs_timer_start_wrapper(PyObject *self, PyObject *args, PyObject *kwd
     int times = 0;
     PyObject *callback = NULL;
     PyObject *my_data = NULL;
-    if (PyArg_ParseTupleAndKeywords(args, NULL, "ii00", kwlist, &delay, &times, &callback, &my_data)) {
+    if (PyArg_ParseTupleAndKeywords(args, NULL, "iiOO", kwlist, &delay, &times, &callback, &my_data)) {
         if (!PyCallable_Check(callback)) {
             PyErr_SetString(PyExc_TypeError, "'callback' parameter must be callable");
             return PyLong_FromLong(IGS_FAILURE);


### PR DESCRIPTION
A typo in the parsing format string causes crashes.

Solution: Fix that typo