### PR TITLE
Problem: The arguments list passed to igsagent_service_call may be leaked in a specific error case

### DIFF
--- a/include/ingescape.h
+++ b/include/ingescape.h
@@ -32,7 +32,7 @@
 //  INGESCAPE version macros for compile-time API detection
 #define INGESCAPE_VERSION_MAJOR 3
 #define INGESCAPE_VERSION_MINOR 5
-#define INGESCAPE_VERSION_PATCH 3
+#define INGESCAPE_VERSION_PATCH 4
 
 #define INGESCAPE_MAKE_VERSION(major, minor, patch) \
 ((major) * 10000 + (minor) * 100 + (patch))

--- a/src/igs_service.c
+++ b/src/igs_service.c
@@ -766,6 +766,10 @@ igs_result_t igsagent_service_call (igsagent_t *agent,
     model_read_write_lock (__FUNCTION__, __LINE__);
     // check that this agent has not been destroyed when we were locked
     if (!agent || !(agent->uuid)) {
+        if ((list) && (*list)) {
+            s_service_free_service_arguments (*list);
+            *list = NULL;
+        }
         model_read_write_unlock (__FUNCTION__, __LINE__);
         return IGS_SUCCESS;
     }


### PR DESCRIPTION
Solution: Always free the args list when using igsagent_service_call, as stated in the documentation.

I also incremented the PATCH version number to publish this new version, including previous PR that were still on the previous version (mostly python bindings fixes)