### PR TITLE
Problem: Crashes due to a double-free encountered when receiving a publication from other agents

### DIFF
--- a/src/igs_network.c
+++ b/src/igs_network.c
@@ -308,9 +308,8 @@ void s_handle_publication (zmsg_t **msg, igs_remote_agent_t *remote_agent)
         if (frame)
             zframe_destroy (&frame);
         if (value)
-            free (value);
-        free (output);
-        output = NULL;
+            freen (value);
+        freen (output);
     }
     zmsg_destroy (msg);
     model_read_write_unlock (__FUNCTION__, __LINE__);


### PR DESCRIPTION
A variable used in a loop is freed but not set to NULL. The next loop iteration may cause a double-free if the variable is not reallocated.

Solution: Use `freen` macro from czmq to ensure that freed variables are also set to NULL.


ASAN report of the double-free error
```
=================================================================
==34283==ERROR: AddressSanitizer: attempting double-free on 0x602000021fb0 in thread T5:
    #0 0x7ffff6f026b8 in __interceptor_free ../../.././libsanitizer/asan/asan_malloc_linux.cc:45
    #1 0x7ffff6bbb4ee in s_handle_publication /appli/ckr/comp/src/ingescape/src/igs_network.c:311
    #2 0x7ffff6bc7223 in s_manage_zyre_incoming /appli/ckr/comp/src/ingescape/src/igs_network.c:1534
    #3 0x7ffff691f871 in zloop_start /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zloop.c:804
    #4 0x7ffff6bd6f36 in s_run_loop /appli/ckr/comp/src/ingescape/src/igs_network.c:3045
    #5 0x7ffff68fbc16 in s_thread_shim /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zactor.c:68
    #6 0x7ffff5f47dd4 in start_thread (/lib64/libpthread.so.0+0x7dd4)
    #7 0x7ffff555002c in __clone (/lib64/libc.so.6+0xfe02c)

0x602000021fb0 is located 0 bytes inside of 12-byte region [0x602000021fb0,0x602000021fbc)
freed by thread T5 here:
    #0 0x7ffff6f026b8 in __interceptor_free ../../.././libsanitizer/asan/asan_malloc_linux.cc:45
    #1 0x7ffff6bbb4ee in s_handle_publication /appli/ckr/comp/src/ingescape/src/igs_network.c:311
    #2 0x7ffff6bc7223 in s_manage_zyre_incoming /appli/ckr/comp/src/ingescape/src/igs_network.c:1534
    #3 0x7ffff691f871 in zloop_start /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zloop.c:804
    #4 0x7ffff6bd6f36 in s_run_loop /appli/ckr/comp/src/ingescape/src/igs_network.c:3045
    #5 0x7ffff68fbc16 in s_thread_shim /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zactor.c:68
    #6 0x7ffff5f47dd4 in start_thread (/lib64/libpthread.so.0+0x7dd4)

previously allocated by thread T5 here:
    #0 0x7ffff6f02a10 in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x7ffff6910e80 in zframe_strdup /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zframe.c:346
    #2 0x7ffff69212e4 in zmsg_popstr /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zmsg.c:449
    #3 0x7ffff6bba856 in s_handle_publication /appli/ckr/comp/src/ingescape/src/igs_network.c:166
    #4 0x7ffff6bc7223 in s_manage_zyre_incoming /appli/ckr/comp/src/ingescape/src/igs_network.c:1534
    #5 0x7ffff691f871 in zloop_start /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zloop.c:804
    #6 0x7ffff6bd6f36 in s_run_loop /appli/ckr/comp/src/ingescape/src/igs_network.c:3045
    #7 0x7ffff68fbc16 in s_thread_shim /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zactor.c:68
    #8 0x7ffff5f47dd4 in start_thread (/lib64/libpthread.so.0+0x7dd4)

Thread T5 created by T0 here:
    #0 0x7ffff6e60180 in __interceptor_pthread_create ../../.././libsanitizer/asan/asan_interceptors.cc:243
    #1 0x7ffff68fbdfd in zactor_new /appli/ckr/comp/src/ingescape/dependencies/czmq/src/zactor.c:125
    #2 0x7ffff6bd9018 in s_init_loop /appli/ckr/comp/src/ingescape/src/igs_network.c:3459
    #3 0x7ffff6bda147 in igs_start_with_device /appli/ckr/comp/src/ingescape/src/igs_network.c:3743
    #4 0x42be25 in startAgent /appli/ckr/comp/src/cockpitrer/indicators/common/abstractindicator.cpp:728
    #5 0x423c68 in main /appli/ckr/comp/src/cockpitrer/indicators/common/main.cpp:243
    #6 0x7ffff5474494 in __libc_start_main (/lib64/libc.so.6+0x22494)

SUMMARY: AddressSanitizer: double-free ../../.././libsanitizer/asan/asan_malloc_linux.cc:45 in __interceptor_free
==34283==ABORTING
```