### PR TITLE
Problem: enable_security API throws an exception upon use

### DIFF
--- a/bindings/python/src/network.c
+++ b/bindings/python/src/network.c
@@ -249,7 +249,7 @@ PyObject * igs_enable_security_wrapper(PyObject *self, PyObject *args, PyObject 
     static char *kwlist[] = {"private_certificate_file", "public_certificates_directory",  NULL};
     char *private_certificate_file = NULL;
     char *public_certificates_directory = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, NULL, "s", kwlist, &private_certificate_file, &public_certificates_directory))
+    if (!PyArg_ParseTupleAndKeywords(args, NULL, "ss", kwlist, &private_certificate_file, &public_certificates_directory))
         return NULL;
     return PyLong_FromLong(igs_enable_security(private_certificate_file, public_certificates_directory));
 }

--- a/bindings/python/tests/global_api.py
+++ b/bindings/python/tests/global_api.py
@@ -81,6 +81,22 @@ igs.log_set_syslog(False)
 assert igs.version() > 0
 assert igs.protocol() >= 2
 
+print ("[Global API] Security")
+print ("Test certificates are in the tests/security directory")
+print ("Wrong path")
+assert igs.enable_security("/does/not/exist", "/does/not/exist") == igs.FAILURE
+print ("Wrong parameter types")
+try:
+    igs.enable_security(42, None) == igs.FAILURE
+    assert False, "An exception must be thrown"
+except:
+    pass
+print ("OK path")
+assert igs.enable_security("./security/private.cert_secret", "./security") == igs.SUCCESS
+print ("Disable security")
+assert igs.disable_security() == igs.SUCCESS
+print ("OK")
+
 assert not igs.mapping_outputs_request()
 igs.mapping_set_outputs_request(True)
 assert igs.mapping_outputs_request()

--- a/bindings/python/tests/run_tests.sh
+++ b/bindings/python/tests/run_tests.sh
@@ -18,7 +18,10 @@ SCRIPT_DIR=$(cd `dirname $0`; pwd)
 
 python3 -m pip install $SCRIPT_DIR/..
 
-echo -e "\n\n**** GLOBAL API ***************************"
-python3 $SCRIPT_DIR/global_api.py
-echo -e "\n\n**** AGENT API ***************************"
-python3 $SCRIPT_DIR/agent_api.py
+(
+    cd $SCRIPT_DIR
+    echo -e "\n\n**** GLOBAL API ***************************"
+    python3 $SCRIPT_DIR/global_api.py
+    echo -e "\n\n**** AGENT API ***************************"
+    python3 $SCRIPT_DIR/agent_api.py
+)

--- a/bindings/python/tests/security/private.cert_secret
+++ b/bindings/python/tests/security/private.cert_secret
@@ -1,0 +1,10 @@
+#   ****  Generated on 2021-05-10 15:34:20 by CZMQ  ****
+#   ZeroMQ CURVE **Secret** Certificate
+#   DO NOT PROVIDE THIS FILE TO OTHER USERS nor change its permissions.
+
+metadata
+    date-created = "2021-05-10 15:34:20"
+    created-by = "CZMQ zmakecert"
+curve
+    public-key = "TVwAV!3=wY+D2GvkQt6Ug/f}QaFa?d5aT$E7HbAr"
+    secret-key = "Eu+odGj6gk0KHXNt0:.v&H]%#lO-@496T:<MTk[."

--- a/bindings/python/tests/security/public.cert
+++ b/bindings/python/tests/security/public.cert
@@ -1,0 +1,11 @@
+#   ****  Generated on 2021-05-10 15:34:20 by CZMQ  ****
+#   ZeroMQ CURVE Public Certificate
+#   Exchange securely, or use a secure mechanism to verify the contents
+#   of this file after exchange. Store public certificates in your home
+#   directory, in the .curve subdirectory.
+
+metadata
+    date-created = "2021-05-10 15:34:20"
+    created-by = "CZMQ zmakecert"
+curve
+    public-key = "TVwAV!3=wY+D2GvkQt6Ug/f}QaFa?d5aT$E7HbAr"


### PR DESCRIPTION
The wrapper code declares that it needs 2 parameters but then only accepts one in its code.

Solution: Both parameters must be taken into account and passed to the C API.  
I also added test code corresponding to enable_security to catch future problems.