### PR TITLE
Problem: igs timer callback is not thread safe 

### DIFF
--- a/include/ingescape.h
+++ b/include/ingescape.h
@@ -32,7 +32,7 @@
 //  INGESCAPE version macros for compile-time API detection
 #define INGESCAPE_VERSION_MAJOR 3
 #define INGESCAPE_VERSION_MINOR 6
-#define INGESCAPE_VERSION_PATCH 1
+#define INGESCAPE_VERSION_PATCH 2
 
 #define INGESCAPE_MAKE_VERSION(major, minor, patch) \
 ((major) * 10000 + (minor) * 100 + (patch))

--- a/src/igs_network.c
+++ b/src/igs_network.c
@@ -4901,6 +4901,7 @@ void igs_timer_stop (int timer_id)
         zloop_timer_end (core_context->loop, timer_id);
         HASH_DEL (core_context->timers, timer);
         free (timer);
+        timer = NULL;
     }
     else
         igs_error ("could not find timer with id %d", timer_id);

--- a/src/igs_network.c
+++ b/src/igs_network.c
@@ -3671,7 +3671,10 @@ int network_timer_callback (zloop_t *loop, int timer_id, void *arg)
     IGS_UNUSED (loop)
     IGS_UNUSED (timer_id)
     igs_timer_t *timer = (igs_timer_t *) arg;
-    timer->cb (timer->timer_id, timer->my_data);
+    s_network_lock ();
+    if (timer != NULL)
+        timer->cb (timer->timer_id, timer->my_data);
+    s_network_unlock ();
     return 1;
 }
 


### PR DESCRIPTION
Timer callback can be executed at the same time as another thread calls the igs_timer_stop method and thus access a freed pointer of an igs_timer_t.

Solution: Add same mutex as in creation/deletion in the timeout callback to access the igs_timer_t