### PR TITLE
Problem : deadlock in igs methods used in igs timer callback

### DIFF
--- a/include/ingescape.h
+++ b/include/ingescape.h
@@ -32,7 +32,7 @@
 //  INGESCAPE version macros for compile-time API detection
 #define INGESCAPE_VERSION_MAJOR 3
 #define INGESCAPE_VERSION_MINOR 6
-#define INGESCAPE_VERSION_PATCH 2
+#define INGESCAPE_VERSION_PATCH 3
 
 #define INGESCAPE_MAKE_VERSION(major, minor, patch) \
 ((major) * 10000 + (minor) * 100 + (patch))

--- a/src/igs_network.c
+++ b/src/igs_network.c
@@ -3672,9 +3672,12 @@ int network_timer_callback (zloop_t *loop, int timer_id, void *arg)
     IGS_UNUSED (timer_id)
     igs_timer_t *timer = (igs_timer_t *) arg;
     s_network_lock ();
-    if (timer != NULL)
+    if (timer != NULL){
+        s_network_unlock (); //unlock to allow user callback to use other igs methods
         timer->cb (timer->timer_id, timer->my_data);
-    s_network_unlock ();
+    }
+    else
+        s_network_unlock ();
     return 1;
 }
 


### PR DESCRIPTION
Introduced in the previous PR 

Solution: unlock the mutex before the call of the user igs timer callback