### PR TITLE
Include prebuilds into NPM package

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -761,7 +761,8 @@ binding-node-js-macos:
     - sed -i .bak 's@/usr/local@<!(echo $PWD)/dependencies@g' binding.gyp #update file paths for igs
     - cat ./binding.gyp
     - npm install -g prebuildify
-    - npm run build --from_sources=1
+    - prebuildify --napi --arch x64
+    - prebuildify --napi --arch arm64
   artifacts:
     paths:
       - bindings/javascript-node/prebuilds

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,13 +54,22 @@ lib-build-macos:
   extends: .lib-build-files
   stage: lib-build
   tags:
-    - osx
+    - macos-qt6
   before_script:
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
   script:
     - git clean -xfd
-    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_DEPS=ON
+    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_DEPS=ON -DOSX_UNIVERSAL=ON
     - make -j8 -C build
+    - |
+      if [[ $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH ]]
+      then
+        make -C build DESTDIR=$HOME/builds/sysroot install
+        make -C build DESTDIR=temp install
+        mkdir -p $ARTIFACTS_NET_SHARE/macos/binaries/ingescape
+        rm -rf $ARTIFACTS_NET_SHARE/macos/binaries/ingescape/*
+        cp -RLf build/temp/usr/local/* $ARTIFACTS_NET_SHARE/macos/binaries/ingescape
+      fi
   artifacts:
     paths:
       - ./build
@@ -82,7 +91,7 @@ lib-installer-macos:
   extends: .lib-build-files
   stage: lib-installer
   tags:
-    - osx
+    - macos-qt6
   script:
     - make -C build package
 #    - packagesbuild ./builds/xcode/ingescape.pkgproj
@@ -102,48 +111,24 @@ lib-installer-macos:
     - lib-build-macos
 
 
-lib-deploy-macos:
+# Build/Deploy ingescape on OSX (cyclone) runner
+# Cyclone runner shall not be used in the future. This job is here to keep old pipelines working with the latest ingescape version.
+lib-deploy-on-old-macos-runner:
   extends: .lib-build-files
   stage: deploy
   tags:
     - osx
-  script:
-    - make -C build DESTDIR=$HOME/builds/sysroot install
-  dependencies:
-    - lib-build-macos
-  needs:
-    - lib-build-macos
-  rules:
-    - !reference [.root_namespace, rules]
-
-
-
-# Build/Deploy ingescape on macos-qt6 runner
-lib-build-macos-qt6:
-  extends: .lib-build-files
-  stage: lib-build
-  tags:
-    - macos-qt6
   before_script:
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
   script:
     - git clean -xfd
-    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DOSX_UNIVERSAL=ON -DWITH_DEPS=ON
-    - make -j8 -C build
-    - |
-      if [[ $CI_PROJECT_ROOT_NAMESPACE == "ingescape-private" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH ]]
-      then
-        make -C build DESTDIR=$HOME/builds/sysroot install
-        make -C build DESTDIR=temp install
-        mkdir -p $ARTIFACTS_NET_SHARE/macos/binaries/ingescape
-        rm -rf $ARTIFACTS_NET_SHARE/macos/binaries/ingescape/*
-        cp -RLf build/temp/usr/local/* $ARTIFACTS_NET_SHARE/macos/binaries/ingescape
-      fi
-  artifacts:
-    paths:
-      - ./build
-    name: "lib-build-macos"
-    expire_in: 1 day
+    - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DWITH_DEPS=ON
+    - make -C build DESTDIR=$HOME/builds/sysroot install
+  dependencies: []
+  needs:
+    - lib-build-macos
+  rules:
+    - !reference [.root_namespace, rules]
 
 
 #__          ___           _
@@ -743,6 +728,8 @@ binding-node-js-macos:
   stage: binding-build
   tags:
     - macos-qt6
+  before_script:
+    - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
   script:
     - cd ./bindings/javascript-node/
     - mkdir -p ./dependencies/lib
@@ -761,8 +748,10 @@ binding-node-js-macos:
     - sed -i .bak 's@/usr/local@<!(echo $PWD)/dependencies@g' binding.gyp #update file paths for igs
     - cat ./binding.gyp
     - npm install -g prebuildify
-    - prebuildify --napi --arch x64
-    - prebuildify --napi --arch arm64
+    - export PREBUILD_ARCH=x64
+    - npm run build --from_sources=1
+    - export PREBUILD_ARCH=arm64
+    - npm run build --from_sources=1
   artifacts:
     paths:
       - bindings/javascript-node/prebuilds
@@ -776,6 +765,8 @@ binding-node-js-linux:
   tags:
     - docker
   image: ingescape/ubuntu18.04-node
+  before_script:
+    - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
   script:
     - cd ./bindings/javascript-node/
     - mkdir -p ./dependencies/lib

--- a/bindings/javascript-node/.npmignore
+++ b/bindings/javascript-node/.npmignore
@@ -1,7 +1,5 @@
 node_modules
 build
-examples
 package-lock.json
-prebuilds
 tests
 *.bak


### PR DESCRIPTION
The fix only consists of removing some files from the `.npmignore` file.  
This PR also includes changes to the pipeline to build the nodejs binding for both darwin-x64 and darwin-arm64.