### PR TITLE
Change old OSX runner job tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,7 +113,7 @@ lib-deploy-on-old-macos-runner:
   extends: .lib-build-files
   stage: deploy
   tags:
-    - osx
+    - old-osx
   before_script:
     - git -c url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ingescape.com/".insteadOf="ssh://git@gitlab.ingescape.com:22222/" submodule update --init --remote --recursive
   script:


### PR DESCRIPTION
Since the old runner tag has been changed, .gitlab-ci.yml must be updated accordingly.