### PR TITLE
Problem: The "major" shared library file on Unix system has the wrong name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ if (NOT DEPS_ONLY)
                                 #MACOSX_FRAMEWORK_IDENTIFIER com.ingescape
                                 #XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "MyAccount Developer"
                                 VERSION "${INGESCAPE_VERSION}" # Current version
-                                SOVERSION "${INGESCAPE_VERSION_MAJOR}.0.0" # Compatibility version
+                                SOVERSION "${INGESCAPE_VERSION_MAJOR}" # Compatibility version
                                 OUTPUT_NAME "ingescape"
                                 PREFIX "lib"
       )


### PR DESCRIPTION
The "major" shared file name is `libingescape.3.0.0.dylib` instead of `libingescape.3.dylib`. The same thing happens on linux.

Solution: Change the CMakeLists.txt so the major lib (called `SOVERSION`) version has the correct name.