### PR TITLE
Problem: Memory leak when handling DATA type in python

### DIFF
--- a/bindings/python/src/agent.c
+++ b/bindings/python/src/agent.c
@@ -1389,7 +1389,9 @@ PyObject *Agent_input_set_data(AgentObject *self, PyObject *args, PyObject *kwds
     if (!PyArg_ParseTupleAndKeywords(args, NULL, "sy*", kwlist, &name, &buf))
         Py_RETURN_NONE;
 
-    return PyLong_FromLong(igsagent_input_set_data(self->agent, name, buf.buf, (size_t)buf.len));
+    PyObject* result = PyLong_FromLong(igsagent_input_set_data(self->agent, name, buf.buf, (size_t)buf.len));
+    PyBuffer_Release(&buf);
+    return result;
 }
 
 
@@ -1477,7 +1479,9 @@ PyObject *Agent_output_set_data(AgentObject *self, PyObject *args, PyObject *kwd
     if (!PyArg_ParseTupleAndKeywords(args, NULL, "sy*", kwlist, &name, &buf))
         Py_RETURN_NONE;
 
-    return PyLong_FromLong(igsagent_output_set_data(self->agent, name, buf.buf, (size_t)buf.len));
+    PyObject* result = PyLong_FromLong(igsagent_output_set_data(self->agent, name, buf.buf, (size_t)buf.len));
+    PyBuffer_Release(&buf);
+    return result;
 }
 
 
@@ -1553,7 +1557,9 @@ PyObject *Agent_parameter_set_data(AgentObject *self, PyObject *args, PyObject *
     if (!PyArg_ParseTupleAndKeywords(args, NULL, "sy*", kwlist, &name, &buf))
         Py_RETURN_NONE;
 
-    return PyLong_FromLong(igsagent_parameter_set_data(self->agent, name, buf.buf, (size_t)buf.len));
+    PyObject* result = PyLong_FromLong(igsagent_parameter_set_data(self->agent, name, buf.buf, (size_t)buf.len));
+    PyBuffer_Release(&buf);
+    return result;
 }
 
 PyObject *Agent_clear_input(AgentObject *self, PyObject *args, PyObject *kwds)

--- a/bindings/python/src/channels.c
+++ b/bindings/python/src/channels.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) the Contributors as noted in the AUTHORS file.
  * This file is part of Ingescape, see https://github.com/zeromq/ingescape.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -27,7 +27,7 @@ PyObject * channel_join_wrapper(PyObject *self, PyObject *args)
 PyObject * channel_leave_wrapper(PyObject *self, PyObject *args)
 {
     char *channel;
-    if (!PyArg_ParseTuple(args, "s", &channel)) 
+    if (!PyArg_ParseTuple(args, "s", &channel))
         return NULL;
     igs_channel_leave(channel);
     return PyLong_FromLong(IGS_SUCCESS);
@@ -51,9 +51,11 @@ PyObject * channel_shout_data_wrapper(PyObject *self, PyObject *args)
     char * channel;
     size_t size;
     Py_buffer buf;
-    if (!PyArg_ParseTuple(args, "sy*k", &channel, &buf, &size)) 
+    if (!PyArg_ParseTuple(args, "sy*k", &channel, &buf, &size))
         return NULL;
-    return PyLong_FromLong(igs_channel_shout_data(channel, buf.buf, size));
+    PyObject* result = PyLong_FromLong(igs_channel_shout_data(channel, buf.buf, size));
+    PyBuffer_Release(&buf);
+    return result;
 }
 
 PyObject * channel_whisper_str_wrapper(PyObject *self, PyObject *args)
@@ -71,7 +73,9 @@ PyObject * channel_whisper_data_wrapper(PyObject *self, PyObject *args)
     Py_buffer buf;
     if (!PyArg_ParseTuple(args, "sy*k", &agentNameOrPeerID, &buf, &size))
         return NULL;
-    return PyLong_FromLong(igs_channel_whisper_data(agentNameOrPeerID, buf.buf, size));
+    PyObject* result = PyLong_FromLong(igs_channel_whisper_data(agentNameOrPeerID, buf.buf, size));
+    PyBuffer_Release(&buf);
+    return result;
 }
 
 PyObject * peer_add_header_wrapper(PyObject *self, PyObject *args)

--- a/bindings/python/src/core.c
+++ b/bindings/python/src/core.c
@@ -453,7 +453,9 @@ PyObject * input_set_data_wrapper(PyObject * self, PyObject * args)
     Py_buffer buf;
     if (!PyArg_ParseTuple(args, "sy*", &name, &buf))
         return NULL;
-    return PyLong_FromLong(igs_input_set_data(name, buf.buf, (size_t)buf.len));
+    PyObject* result = PyLong_FromLong(igs_input_set_data(name, buf.buf, (size_t)buf.len));
+    PyBuffer_Release(&buf);
+    return result;
 }
 
 PyObject * output_bool_wrapper(PyObject * self, PyObject * args)
@@ -555,16 +557,18 @@ PyObject * output_set_impulsion_wrapper(PyObject * self, PyObject * args)
 
 PyObject * output_set_data_wrapper(PyObject * self, PyObject * args)
 {
-    char * name;
+    const char * name;
     Py_buffer buf;
     if (!PyArg_ParseTuple(args, "sy*", &name, &buf))
         return NULL;
-    return PyLong_FromLong(igs_output_set_data(name, buf.buf, (size_t)buf.len));
+    PyObject* result = PyLong_FromLong(igs_output_set_data(name, buf.buf, (size_t)buf.len));
+    PyBuffer_Release(&buf);
+    return result;
 }
 
 PyObject * parameter_bool_wrapper(PyObject * self, PyObject * args)
 {
-    char * name;
+    const char * name;
     if (!PyArg_ParseTuple(args, "s", &name))
         return NULL;
     if (igs_parameter_bool(name))
@@ -657,7 +661,9 @@ PyObject * parameter_set_data_wrapper(PyObject * self, PyObject * args)
     Py_buffer buf;
     if (!PyArg_ParseTuple(args, "sy*", &name, &buf))
         return NULL;
-    return PyLong_FromLong(igs_parameter_set_data(name, buf.buf, (size_t)buf.len));
+    PyObject* result = PyLong_FromLong(igs_parameter_set_data(name, buf.buf, (size_t)buf.len));
+    PyBuffer_Release(&buf);
+    return result;
 }
 
 PyObject * clear_input_wrapper(PyObject * self, PyObject * args)

--- a/include/ingescape.h
+++ b/include/ingescape.h
@@ -32,7 +32,7 @@
 //  INGESCAPE version macros for compile-time API detection
 #define INGESCAPE_VERSION_MAJOR 3
 #define INGESCAPE_VERSION_MINOR 8
-#define INGESCAPE_VERSION_PATCH 1
+#define INGESCAPE_VERSION_PATCH 2
 
 #define INGESCAPE_MAKE_VERSION(major, minor, patch) \
 ((major) * 10000 + (minor) * 100 + (patch))


### PR DESCRIPTION
The problem is due to a mishandling of a PyObject reference at the boundary between python and C

Solution: Clean up those references properly when we are done with the DATA value.
Bump up the patch version to be able to publish a new python package.