### PR TITLE
fix buffer overflow detected

### DIFF
--- a/src/igs_network.c
+++ b/src/igs_network.c
@@ -3166,7 +3166,7 @@ void s_init_loop (igs_core_context_t *context)
     // create channel for replay
     assert (context->replay_channel == NULL);
     context->replay_channel = (char *) zmalloc (strlen (core_agent->definition->name) + strlen ("-IGS-REPLAY") + 1);
-    snprintf (context->replay_channel, IGS_MAX_AGENT_NAME_LENGTH + 15,
+    snprintf (context->replay_channel, strlen (core_agent->definition->name) + strlen ("-IGS-REPLAY") + 1,
               "%s-IGS-REPLAY", core_agent->definition->name);
     s_lock_zyre_peer (__FUNCTION__, __LINE__);
     zyre_join (context->node, context->replay_channel);
@@ -3913,7 +3913,7 @@ void igsagent_set_name (igsagent_t *agent, const char *name)
             //name is already set in definition but channel is not set yet
             //NB: this happens when a JSON definition is loaded
             agent->igs_channel = (char *) zmalloc (strlen (agent->definition->name) + strlen ("-IGS") + 1);
-            snprintf (agent->igs_channel, IGS_MAX_AGENT_NAME_LENGTH + strlen ("-IGS") + 1,
+            snprintf (agent->igs_channel, strlen (agent->definition->name) + strlen ("-IGS") + 1,
                       "%s-IGS", agent->definition->name);
         }
         model_read_write_unlock(__FUNCTION__, __LINE__);
@@ -3948,13 +3948,13 @@ void igsagent_set_name (igsagent_t *agent, const char *name)
     if (agent->igs_channel)
         free (agent->igs_channel);
     agent->igs_channel = (char *) zmalloc (strlen (agent->definition->name) + strlen ("-IGS") + 1);
-    snprintf (agent->igs_channel, IGS_MAX_AGENT_NAME_LENGTH + strlen ("-IGS") + 1,
+    snprintf (agent->igs_channel, strlen (agent->definition->name) + strlen ("-IGS") + 1,
               "%s-IGS", agent->definition->name);
 
     if (agent->context && agent->context->node) {
         if (previous) {
             char *previous_igs_channel = (char *) zmalloc (strlen (previous) + strlen ("-IGS") + 1);
-            snprintf (previous_igs_channel, IGS_MAX_AGENT_NAME_LENGTH + strlen("-IGS") + 1, "%s-IGS", previous);
+            snprintf (previous_igs_channel, strlen (previous) + strlen("-IGS") + 1, "%s-IGS", previous);
             s_lock_zyre_peer (__FUNCTION__, __LINE__);
             zyre_leave (agent->context->node, previous_igs_channel);
             s_unlock_zyre_peer (__FUNCTION__, __LINE__);


### PR DESCRIPTION
Hi,

This PR is fixing when build in release :
```
igsPartner --device eth0
*** buffer overflow detected ***: terminated
Aborted (core dumped)
```
```
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007f15b9ba826e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007f15b9b8b8ff in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007f15b9b8c7b6 in __libc_message_impl (fmt=fmt@entry=0x7f15b9d31765 "*** %s ***: terminated\n") at ../sysdeps/posix/libc_fatal.c:132
#6  0x00007f15b9c99c19 in __GI___fortify_fail (msg=msg@entry=0x7f15b9d3174c "buffer overflow detected") at ./debug/fortify_fail.c:24
#7  0x00007f15b9c995d4 in __GI___chk_fail () at ./debug/chk_fail.c:28
#8  0x00007f15b9c9adb5 in ___snprintf_chk (s=<optimized out>, maxlen=<optimized out>, flag=<optimized out>, slen=<optimized out>, format=<optimized out>) at ./debug/snprintf_chk.c:29
#9  0x00007f15b9e63bf2 in igsagent_new () from /usr/local/lib/libingescape.so.4
#10 0x00007f15b9e225ee in core_init_agent () from /usr/local/lib/libingescape.so.4
#11 0x00007f15b9e2262d in igs_agent_set_name () from /usr/local/lib/libingescape.so.4
#12 0x00005588d49fadbc in main ()
```

Next there is a similar problem in czmq/ziflist.c/s_reload 

Best Regards,
Michel.