### PR TITLE
Fix a bunch of compilation warnings

### DIFF
--- a/src/igs_model.c
+++ b/src/igs_model.c
@@ -784,7 +784,7 @@ size_t model_clean_string(char *string, int64_t max){
         max = INT64_MAX;
     char *char_index = string;
     size_t offset = 0;
-    size_t write_index = 0;
+    int64_t write_index = 0;
     while (1) {
         while (*(char_index+offset) == '\t'
             || *(char_index+offset) == '\v'
@@ -812,7 +812,7 @@ bool model_check_string(const char *string, int64_t max){
     assert(string);
     if (max <= 0)
         max = INT64_MAX;
-    size_t offset = 0;
+    int64_t offset = 0;
     while (1) {
         if (string[offset] == '\t'
             || string[offset] == '\v'

--- a/src/igs_parser.c
+++ b/src/igs_parser.c
@@ -140,12 +140,13 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
     const char *family_path[] = {STR_DEFINITION, STR_FAMILY, NULL};
     const char *type_path[] = {STR_TYPE, NULL};
     const char *replies_path[] = {STR_REPLIES, NULL};
+    size_t changes = 0;
 
     // name is mandatory
     igs_json_node_t *name = igs_json_node_find (*json, agent_name_path);
     if (name && name->type == IGS_JSON_STRING && name->u.string) {
         char *n = s_strndup (name->u.string, IGS_MAX_AGENT_NAME_LENGTH);
-        size_t changes = model_clean_string(n, IGS_MAX_AGENT_NAME_LENGTH);
+        changes = model_clean_string(n, IGS_MAX_AGENT_NAME_LENGTH);
         if (changes)
             igs_warn ("definition name '%s' has been changed to '%s'", name->u.string, n);
         //FIXME: Use a definition method to create the definition
@@ -176,7 +177,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
     igs_json_node_t *class = igs_json_node_find (*json, class_path);
     if (class && class->type == IGS_JSON_STRING && class->u.string){
         definition->my_class = strdup (class->u.string);
-        size_t changes = model_clean_string(definition->my_class, IGS_MAX_AGENT_CLASS_LENGTH);
+        changes = model_clean_string(definition->my_class, IGS_MAX_AGENT_CLASS_LENGTH);
         if (changes)
             igs_warn ("definition class '%s' has been changed to '%s'", class->u.string, definition->my_class);
     }
@@ -185,7 +186,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
     igs_json_node_t *package = igs_json_node_find (*json, package_path);
     if (package && package->type == IGS_JSON_STRING && package->u.string){
         definition->package = strdup (package->u.string);
-        size_t changes = model_clean_string(definition->package, IGS_MAX_AGENT_PACKAGE_LENGTH);
+        changes = model_clean_string(definition->package, IGS_MAX_AGENT_PACKAGE_LENGTH);
         if (changes)
             igs_warn ("definition package '%s' has been changed to '%s'", package->u.string, definition->package);
     }
@@ -194,7 +195,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
     igs_json_node_t *family = igs_json_node_find (*json, family_path);
     if (family && family->type == IGS_JSON_STRING && family->u.string){
         definition->family = s_strndup(family->u.string, IGS_MAX_FAMILY_LENGTH);
-        size_t changes = model_clean_string(definition->family, IGS_MAX_FAMILY_LENGTH);
+        changes = model_clean_string(definition->family, IGS_MAX_FAMILY_LENGTH);
         if (changes)
             igs_warn ("definition family '%s' has been changed to '%s'", family->u.string, definition->family);
     }
@@ -208,7 +209,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
     igs_json_node_t *version = igs_json_node_find (*json, version_path);
     if (version && version->type == IGS_JSON_STRING && version->u.string){
         definition->version = s_strndup(version->u.string, IGS_MAX_VERSION_LENGTH);
-        size_t changes = model_clean_string(definition->version, IGS_MAX_VERSION_LENGTH);
+        changes = model_clean_string(definition->version, IGS_MAX_VERSION_LENGTH);
         if (changes)
             igs_warn ("definition version '%s' has been changed to '%s'", version->u.string, definition->version);
     }
@@ -220,7 +221,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
             igs_json_node_t *io_name = igs_json_node_find (inputs->u.array.values[i], name_path);
             if (io_name && io_name->type == IGS_JSON_STRING && io_name->u.string) {
                 char *corrected_name = s_strndup (io_name->u.string, IGS_MAX_IO_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
                 if (changes)
                     igs_warn ("input name '%s' has been changed to '%s'", io_name->u.string, corrected_name);
                 igs_io_t *io = zhashx_lookup(definition->inputs_table, corrected_name);
@@ -260,7 +261,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
                     if (io->detailed_type)
                         free(io->detailed_type);
                     io->detailed_type = s_strndup(io_detailed_type->u.string, IGS_MAX_DETAILED_TYPE_LENGTH);
-                    size_t changes = model_clean_string(io->detailed_type, IGS_MAX_DETAILED_TYPE_LENGTH);
+                    changes = model_clean_string(io->detailed_type, IGS_MAX_DETAILED_TYPE_LENGTH);
                     if (changes)
                         igs_warn ("input detailed type '%s' has been changed to '%s'", io_detailed_type->u.string, io->detailed_type);
                 }
@@ -285,7 +286,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
             igs_json_node_t *io_name = igs_json_node_find (outputs->u.array.values[i], name_path);
             if (io_name && io_name->type == IGS_JSON_STRING && io_name->u.string) {
                 char *corrected_name = s_strndup (io_name->u.string, IGS_MAX_IO_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
                 if (changes)
                     igs_warn ("output name '%s' has been changed to '%s'", io_name->u.string, corrected_name);
                 igs_io_t *io = zhashx_lookup(definition->outputs_table, corrected_name);
@@ -323,7 +324,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
                     if (io->detailed_type)
                         free(io->detailed_type);
                     io->detailed_type = s_strndup(io_detailed_type->u.string, IGS_MAX_DETAILED_TYPE_LENGTH);
-                    size_t changes = model_clean_string(io->detailed_type, IGS_MAX_DETAILED_TYPE_LENGTH);
+                    changes = model_clean_string(io->detailed_type, IGS_MAX_DETAILED_TYPE_LENGTH);
                     if (changes)
                         igs_warn ("output detailed type '%s' has been changed to '%s'", io_detailed_type->u.string, io->detailed_type);
                 }
@@ -351,7 +352,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
             igs_json_node_t *io_name = igs_json_node_find (attributes->u.array.values[i], name_path);
             if (io_name && io_name->type == IGS_JSON_STRING && io_name->u.string) {
                 char *corrected_name = s_strndup (io_name->u.string, IGS_MAX_IO_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
                 if (changes)
                     igs_warn ("attribute name '%s' has been changed to '%s'", io_name->u.string, corrected_name);
                 igs_io_t *io = zhashx_lookup(definition->attributes_table, corrected_name);
@@ -389,7 +390,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
                     if (io->detailed_type)
                         free(io->detailed_type);
                     io->detailed_type = s_strndup(io_detailed_type->u.string, IGS_MAX_DETAILED_TYPE_LENGTH);
-                    size_t changes = model_clean_string(io->detailed_type, IGS_MAX_DETAILED_TYPE_LENGTH);
+                    changes = model_clean_string(io->detailed_type, IGS_MAX_DETAILED_TYPE_LENGTH);
                     if (changes)
                         igs_warn ("attribute detailed type '%s' has been changed to '%s'", io_detailed_type->u.string, io->detailed_type);
                 }
@@ -417,7 +418,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
               igs_json_node_find (services->u.array.values[i], name_path);
             if (service_name && service_name->type == IGS_JSON_STRING && service_name->u.string) {
                 char *corrected_name = s_strndup (service_name->u.string, IGS_MAX_SERVICE_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_SERVICE_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_SERVICE_NAME_LENGTH);
                 if (changes)
                     igs_warn ("service name '%s' has been changed to '%s'", service_name->u.string, corrected_name);
                 igs_service_t *service = zhashx_lookup(definition->services_table, corrected_name);
@@ -547,6 +548,7 @@ igs_mapping_t *parser_parse_mapping_from_node (igs_json_node_t **json)
     const char *alternate_from_input_path[] = {STR_LEGACY_FROM_INPUT, NULL};
     const char *alternate_to_agent_path[] = {STR_LEGACY_TO_AGENT, NULL};
     const char *alternate_to_output_path[] = {STR_LEGACY_TO_OUTPUT, NULL};
+    size_t changes = 0;
 
     bool use_alternate = false;
     igs_json_node_t *mappings = igs_json_node_find (*json, mappings_path);
@@ -592,21 +594,21 @@ igs_mapping_t *parser_parse_mapping_from_node (igs_json_node_t **json)
             }
             if (from_input_node && from_input_node->type == IGS_JSON_STRING && from_input_node->u.string) {
                 char *corrected_name = s_strndup (from_input_node->u.string, IGS_MAX_IO_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
                 if (changes)
                     igs_warn("mapping input name '%s' has been changed to '%s'", from_input_node->u.string, corrected_name);
                 from_input = corrected_name;
             }
             if (to_agent_node && to_agent_node->type == IGS_JSON_STRING && to_agent_node->u.string) {
                 char *corrected_name = s_strndup (to_agent_node->u.string, IGS_MAX_AGENT_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_AGENT_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_AGENT_NAME_LENGTH);
                 if (changes)
                     igs_warn("mapping agent name '%s' has been changed to '%s'", to_agent_node->u.string, corrected_name);
                 to_agent = corrected_name;
             }
             if (to_output_node && to_output_node->type == IGS_JSON_STRING && to_output_node->u.string) {
                 char *corrected_name = s_strndup (to_output_node->u.string, IGS_MAX_IO_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
                 if (changes)
                     igs_warn("mapping output name '%s' has been changed to '%s'", to_output_node->u.string, corrected_name);
                 to_output = corrected_name;
@@ -666,21 +668,21 @@ igs_mapping_t *parser_parse_mapping_from_node (igs_json_node_t **json)
 
             if (from_input_node && from_input_node->type == IGS_JSON_STRING && from_input_node->u.string) {
                 char *corrected_name = s_strndup (from_input_node->u.string, IGS_MAX_IO_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
                 if (changes)
                     igs_warn("split input name '%s' has been changed to '%s'", from_input_node->u.string, corrected_name);
                 from_input = corrected_name;
             }
             if (to_agent_node && to_agent_node->type == IGS_JSON_STRING && to_agent_node->u.string) {
                 char *corrected_name = s_strndup (to_agent_node->u.string, IGS_MAX_IO_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_AGENT_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_AGENT_NAME_LENGTH);
                 if (changes)
                     igs_warn("split agent name '%s' has been changed to '%s'", to_agent_node->u.string, corrected_name);
                 to_agent = corrected_name;
             }
             if (to_output_node && to_output_node->type == IGS_JSON_STRING && to_output_node->u.string) {
                 char *corrected_name = s_strndup (to_output_node->u.string, IGS_MAX_IO_NAME_LENGTH);
-                size_t changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
+                changes = model_clean_string(corrected_name, IGS_MAX_IO_NAME_LENGTH);
                 if (changes)
                     igs_warn("split output name '%s' has been changed to '%s'", to_output_node->u.string, corrected_name);
                 to_output = corrected_name;

--- a/src/igs_split.c
+++ b/src/igs_split.c
@@ -494,7 +494,7 @@ int split_message_from_splitter (zmsg_t *msg, igs_core_context_t *context)
         return 1;
     }
     
-    zlistx_t *agents = zhashx_values(core_context->agents);
+    zlistx_t *agents = zhashx_values(context->agents);
     igsagent_t *agent = zlistx_first(agents);
     while (agent && agent->uuid) {
         if (streq(agent->uuid, worker_uuid)){

--- a/test/src/tester.c
+++ b/test/src/tester.c
@@ -1909,7 +1909,7 @@ void set_timeCB(igs_io_type_t io_type,
 //
 int main(int argc, const char * argv[]) {
     
-    char *t0 = "Ma classe étrange <(🦄)>";
+    const char *t0 = "Ma classe étrange <(🦄)>";
     char *t1 = strdup("Ma classe étrange <(🦄)>");
     char *t2 = strdup("Ma classe étrange <(🦄)>\n");
     char *t3 = strdup("\nMa classe étrange <(🦄)>");


### PR DESCRIPTION
Helped catch a possible issue in igs_split.c where we used the global core_context instead of the one given in parameter.  
[Link in the diff](https://github.com/zeromq/ingescape/compare/main...Mathsoum:ingescape:compilation_warnings?expand=1#diff-e6e2405d5c57e8b6a31d83877f718645dd668e223a1bb8a590e2bc75be6c4d39R497)