### PR TITLE
Fix memory leaks

### DIFF
--- a/include/ingescape.h
+++ b/include/ingescape.h
@@ -32,7 +32,7 @@
 //  INGESCAPE version macros for compile-time API detection
 #define INGESCAPE_VERSION_MAJOR 4
 #define INGESCAPE_VERSION_MINOR 3
-#define INGESCAPE_VERSION_PATCH 6
+#define INGESCAPE_VERSION_PATCH 7
 
 #define INGESCAPE_MAKE_VERSION(major, minor, patch) \
 ((major) * 10000 + (minor) * 100 + (patch))

--- a/src/igs_definition.c
+++ b/src/igs_definition.c
@@ -102,15 +102,15 @@ igs_result_t definition_add_io_to_definition (igsagent_t *agent,
     }
     switch (io_type) {
         case IGS_INPUT_T:
-            zlist_append(def->inputs_names_ordered, strdup(io->name));
+            zlist_append(def->inputs_names_ordered, io->name);
             zhashx_insert(def->inputs_table, io->name, io);
             break;
         case IGS_OUTPUT_T:
-            zlist_append(def->outputs_names_ordered, strdup(io->name));
+            zlist_append(def->outputs_names_ordered, io->name);
             zhashx_insert(def->outputs_table, io->name, io);
             break;
         case IGS_ATTRIBUTE_T:
-            zlist_append(def->attributes_names_ordered, strdup(io->name));
+            zlist_append(def->attributes_names_ordered, io->name);
             zhashx_insert(def->attributes_table, io->name, io);
             break;
         default:

--- a/src/igs_parser.c
+++ b/src/igs_parser.c
@@ -274,7 +274,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
                         free(io->specification);
                     io->specification = s_strndup(io_specification->u.string, IGS_MAX_SPECIFICATION_LENGTH);
                 }
-                zlist_append(definition->inputs_names_ordered, strdup(io->name));
+                zlist_append(definition->inputs_names_ordered, io->name);
                 zhashx_insert(definition->inputs_table, io->name, io);
             }
         }
@@ -338,7 +338,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
                     io->specification = s_strndup(io_specification->u.string, IGS_MAX_SPECIFICATION_LENGTH);
                 }
 
-                zlist_append(definition->outputs_names_ordered, strdup(io->name));
+                zlist_append(definition->outputs_names_ordered, io->name);
                 zhashx_insert(definition->outputs_table, io->name, io);
             }
         }
@@ -403,7 +403,7 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
                         free(io->specification);
                     io->specification = s_strndup(io_specification->u.string, IGS_MAX_SPECIFICATION_LENGTH);
                 }
-                zlist_append(definition->attributes_names_ordered, strdup(io->name));
+                zlist_append(definition->attributes_names_ordered, io->name);
                 zhashx_insert(definition->attributes_table, io->name, io);
             }
         }
@@ -528,12 +528,12 @@ igs_definition_t *parser_parse_definition_from_node (igs_json_node_t **json)
                                     }
                                 }
                             }
-                            zlist_append(service->replies_names_ordered, strdup(my_reply->name));
+                            zlist_append(service->replies_names_ordered, my_reply->name);
                             zhashx_insert(service->replies, my_reply->name, my_reply);
                         }
                     }
                 }
-                zlist_append(definition->services_names_ordered, strdup(service->name));
+                zlist_append(definition->services_names_ordered, service->name);
                 zhashx_insert(definition->services_table, service->name, service);
             }
         }

--- a/src/igs_service.c
+++ b/src/igs_service.c
@@ -487,7 +487,7 @@ igs_result_t igsagent_service_init (igsagent_t *agent,
         zlist_comparefn(s->replies_names_ordered, (zlist_compare_fn*) strcmp);
         zlist_autofree(s->replies_names_ordered);
         s->replies = zhashx_new();
-        zlist_append(agent->definition->services_names_ordered, strdup(s->name));
+        zlist_append(agent->definition->services_names_ordered, s->name);
         zhashx_insert(agent->definition->services_table, s->name, s);
         definition_update_json (agent->definition);
         agent->network_need_to_send_definition_update = true;
@@ -764,7 +764,7 @@ igs_result_t igsagent_service_reply_add(igsagent_t *agent, const char *service_n
     zlist_comparefn(r->replies_names_ordered, (zlist_compare_fn*) strcmp);
     zlist_autofree(r->replies_names_ordered);
     r->replies = zhashx_new();
-    zlist_append(s->replies_names_ordered, strdup(r->name));
+    zlist_append(s->replies_names_ordered, r->name);
     zhashx_insert(s->replies, r->name, r);
     definition_update_json (agent->definition);
     agent->network_need_to_send_definition_update = true;


### PR DESCRIPTION
XXXX_ordered lists use automatic item destruction (zlist_free), we don't need to duplicate strings